### PR TITLE
Some cleanup.

### DIFF
--- a/CassandraRevisionStore.js
+++ b/CassandraRevisionStore.js
@@ -119,6 +119,7 @@ CRSP.getRevision = function (name, rev, prop, cb) {
 				cb(null, results.rows);
 			}
 		},
+		consistencies = this.consistencies,
 		client = this.client,
 		cql = '',
 		args = [], tid;
@@ -127,12 +128,12 @@ CRSP.getRevision = function (name, rev, prop, cb) {
 		// Build the CQL
 		cql = 'select value from revisions where name = ? and prop = ? limit 1;';
 		args = [name, prop];
-		this.client.execute(cql, args, this.consistencies.read, queryCB);
+		client.execute(cql, args, consistencies.read, queryCB);
 	} else if (/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(rev)) {
 		// By UUID
 		cql = 'select value from revisions where name = ? and prop = ? and tid = ? limit 1;';
 		args = [name, prop, rev];
-		this.client.execute(cql, args, this.consistencies.read, queryCB);
+		client.execute(cql, args, consistencies.read, queryCB);
 	} else {
 		switch(rev.constructor) {
 			case Number:
@@ -141,7 +142,7 @@ CRSP.getRevision = function (name, rev, prop, cb) {
 				// First look up the timeuuid from the revid
 				cql = 'select tid from idx_revisions_by_revid where revid = ? limit 1;';
 				args = [rev];
-				client.execute(cql, args, this.consistencies.read, function (err, results) {
+				client.execute(cql, args, consistencies.read, function (err, results) {
 							if (err) {
 								cb(err);
 							}
@@ -153,7 +154,7 @@ CRSP.getRevision = function (name, rev, prop, cb) {
 								cql = 'select value from revisions where ' +
 									'name = ? and prop = ? and tid = ? limit 1;';
 								args = [name, prop, tid];
-								client.execute(cql, args, this.consistencies.read, queryCB);
+								client.execute(cql, args, consistencies.read, queryCB);
 							}
 						});
 				break;
@@ -162,7 +163,7 @@ CRSP.getRevision = function (name, rev, prop, cb) {
 				tid = tidFromDate(rev);
 				cql = 'select value from revisions where name = ? and prop = ? and tid <= ? limit 1;';
 				args = [name, prop, tid];
-				this.client.execute(cql, args, this.consistencies.read, queryCB);
+				client.execute(cql, args, consistencies.read, queryCB);
 				break;
 		}
 	}

--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,8 @@ curl http://localhost:8000/enwiki/page/Foo?rev/`date -Iseconds`/wikitext
 curl http://localhost:8000/enwiki/page/Foo?rev/6c745300-eb62-11e0-9234-0123456789ab/wikitext
 ```
 
+(note: `date -Iseconds` is `date -u +%FT%T%z`)
+
 ### Troubleshooting
 #### The server connection to Cassandra hangs when testing on localhost
 On Debian, open /etc/cassandra/cassandra-env.sh and uncomment/edit this line

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
 		"connect-busboy": "git+https://github.com/gwicke/connect-busboy.git#master",
 		"node-uuid": "1.x.x",
 		"node-cassandra-cql": "0.3.0"
+	},
+	"scripts": {
+		"start": "node rashomon.js"
 	}
 }

--- a/rashomon-worker.js
+++ b/rashomon-worker.js
@@ -201,7 +201,6 @@ server.get({
 					}
 					res.writeHead(200, {'Content-type': 'text/plain'});
 					res.end(results[0][0]);
-					return next();
 				});
 				return;
 			}


### PR DESCRIPTION
Fixes a bug in CassandraRevisionStore.js where, on callback from
client.execute, `this` isn't bound to the store and consistencies can't
be read.
