### PR TITLE
createTable and durability level option improvements

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -534,15 +534,20 @@ DB.prototype.createTable = function (reverseDomain, req) {
 
     // console.log(JSON.stringify(internalSchema, null, 2));
 
-    var replicationOptions = '';
-    if (req.options && req.options.storageClass && req.options.durabilityLevel) {
-        replicationOptions = "{ 'class': '" + req.options.storageClass
-            + "', 'replication_factor': " + req.options.durabilityLevel + "}";
-    } else {
-        replicationOptions = "{ 'class': 'SimpleStrategy', 'replication_factor': 3 }";
+    // TODO:2014-11-09:gwicke use info from system.{peers,local} to
+    // automatically set up DC replication
+    //
+    // Always use NetworkTopologyStrategy with default 'datacenter1' for easy
+    // extension to cross-DC replication later.
+    var replicationOptions = "{ 'class': 'NetworkTopologyStrategy', 'datacenter1': 3 }";
+
+    if (req.options) {
+        if (req.options.durability === 'low') {
+            replicationOptions = "{ 'class': 'NetworkTopologyStrategy', 'datacenter1': 1 }";
+        }
     }
 
-    self.schemaCache[keyspace] = internalSchema;
+
     return this._createKeyspace(keyspace, consistency, replicationOptions)
     .then(function() {
         return Promise.all([
@@ -585,7 +590,7 @@ DB.prototype._createTable = function (keyspace, schema, tableName, consistency) 
     });
 
     // Finally, create the main data table
-    var cql = 'create table '
+    var cql = 'create table if not exists '
         + cassID(keyspace) + '.' + cassID(tableName) + ' (';
     for (var attr in schema.attributes) {
         var type = schema.attributes[attr];
@@ -653,7 +658,7 @@ DB.prototype._createTable = function (keyspace, schema, tableName, consistency) 
 };
 
 DB.prototype._createKeyspace = function (keyspace, consistency, options) {
-    var cql = 'create keyspace ' + cassID(keyspace)
+    var cql = 'create keyspace if not exists ' + cassID(keyspace)
         + ' WITH REPLICATION = ' + options;
     return this.client.execute_p(cql, [],
             {consistency: consistency || this.defaultConsistency});

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -166,6 +166,23 @@ dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
         throw new Error("Schema version 1 expected, got " + schema.version);
     }
 
+    // Check options
+    if (schema.options) {
+        var opts = schema.options;
+        for (var key in opts) {
+            switch(key) {
+            case 'durability':
+                var val = opts[key];
+                if (val !== 'low' && val !== 'standard') {
+                    throw new Error ('Invalid durability level: ' + opts[key]);
+                }
+                break;
+            default:
+                throw new Error('Unknown option: ' + key);
+            }
+        }
+    }
+
     // Normalize & validate indexes
     schema.index = dbu.validateIndexSchema(schema, schema.index);
     if (!schema.secondaryIndexes) {

--- a/test/index.js
+++ b/test/index.js
@@ -53,7 +53,7 @@ describe('DB backend', function() {
                 // keep extra redundant info for primary bucket table reconstruction
                 domain: 'en.wikipedia.org',
                 table: 'simpleTable',
-                options: { storageClass: 'SimpleStrategy', durabilityLevel: 1 },
+                options: { durability: 'low' },
                 attributes: {
                     key: 'string',
                     tid: 'timeuuid',
@@ -81,7 +81,7 @@ describe('DB backend', function() {
             return DB.createTable('org.wikipedia.en', {
                 domain: 'en.wikipedia.org',
                 table: 'multiRangeTable',
-                options: { storageClass: 'SimpleStrategy', durabilityLevel: 1 },
+                options: { durability: 'low' },
                 attributes: {
                     key: 'string',
                     tid: 'timeuuid',
@@ -106,7 +106,7 @@ describe('DB backend', function() {
             return DB.createTable('org.wikipedia.en', {
                 domain: 'en.wikipedia.org',
                 table: 'simpleSecondaryIndexTable',
-                options: { storageClass: 'SimpleStrategy', durabilityLevel: 1 },
+                options: { durability: 'low' },
                 attributes: {
                     key: 'string',
                     tid: 'timeuuid',
@@ -135,7 +135,7 @@ describe('DB backend', function() {
             return DB.createTable('org.wikipedia.en', {
                 domain: 'en.wikipedia.org',
                 table: 'unversionedSecondaryIndexTable',
-                options: { storageClass: 'SimpleStrategy', durabilityLevel: 1 },
+                options: { durability: 'low' },
                 attributes: {
                     key: 'string',
                     //tid: 'timeuuid',


### PR DESCRIPTION
- Always create per-table keyspaces using NetworkTopologyStrategy, so that we
  can easily switch to cross-DC replication later.
- Validate schema options
- Support an abstract durability level. For now, only 'low' and 'standard' are
  supported.
- Make table creation conditional to handle a race condition between multiple
  workers on setup
