### PR TITLE
Integrate jshint into the mocha tests

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+node_modules
+test

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "mocha"
   },
   "devDependencies": {
-    "mocha": "x.x.x"
+    "mocha": "x.x.x",
+    "mocha-jshint": "0.0.9"
   }
 }

--- a/test/jshint.spec.js
+++ b/test/jshint.spec.js
@@ -1,0 +1,1 @@
+require('mocha-jshint')();


### PR DESCRIPTION
Copied from https://github.com/wikimedia/restbase/pull/28 - again we ignore both the _node_modules_ and _test_ directories.
