### PR TITLE
Partially handle predicate attributes

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -23,6 +23,32 @@ function DB (client, options) {
     this.schemaCache = {};
 }
 
+function convert(value, fn) {
+    if (value === null || value.constructor !== Object) {
+        return fn(value);
+    } else {
+        var predKeys = Object.keys(value);
+        if (predKeys.length === 1) {
+            var predOp = predKeys[0];
+            var predArg = value[predOp];
+            switch (predOp.toLowerCase()) {
+                case 'eq':
+                case 'lt':
+                case 'gt':
+                case 'le':
+                case 'ge':
+                case 'ne': value[predOp] = fn(predArg); break;
+                case 'between': value[predOp] = [fn(predArg[0]), fn(predArg[1])];
+                                break;
+                default: throw new Error ('Operator ' + predOp + ' not supported!');
+            }
+            return value;
+        } else {
+            throw new Error ('Invalid predicate ' + JSON.stringify(value));
+        }
+    }
+}
+
 // Info table schema
 DB.prototype.infoSchema = dbu.validateAndNormalizeSchema({
     table: 'meta',
@@ -112,7 +138,7 @@ DB.prototype._get = function (keyspace, req, consistency, table, schema) {
         schema.conversions.write.forEach(function(conv) {
             var val = req.attributes[conv.att];
             if (val) {
-                req.attributes[conv.att] = conv.fn(val);
+                req.attributes[conv.att] = convert(val, conv.fn);
             }
         });
     }


### PR DESCRIPTION
This resolves the immediate need for `varint` predicates in queries.  It is not a complete/general solution for conversion of arbitrary attributes, which is going to be rather more invasive, since we'll not only need to track down everywhere they're converted to cql but also take care not to double-convert values.

I'm submitting this PR for consideration as a temporary solution, since it unblocks the current `tid` range query capability that we need in https://github.com/wikimedia/restbase.

Fixes #38
