### PR TITLE
Enable TCP keepalive in the cassandra driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "dependencies": {
     "async": "0.x.x",
     "bluebird": "~2.3.10",


### PR DESCRIPTION
Temporarily use a patched version of the cassandra driver with TCP keepalive
enabled. We are seeing cassandra connection hangs in production, in particular
after an unclean cassandra shutdown (OOM). This then causes client connections
to pile up in the worker, which in turn uses a lot of memory until the client
runs out of memory as well & is restarted by the coordinator.

Lets see if this helps.
