### PR TITLE
fix getSchema to return null for unknown keyspace

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -95,6 +95,13 @@ DB.prototype._getSchema = function (keyspace, consistency) {
         } else {
             return null;
         }
+    }).catch(function(err) {
+        // do not throw error if table does not exists
+        if (err instanceof Object && err.code === 8704) {
+            return null;
+        } else {
+            throw err;
+        }
     });
 };
 


### PR DESCRIPTION
Get Schema seems to throw an error when called upon a keyspace that does not exists, it should return null instead, below is the Error trace I get on calling getSchema on keyspace that does not exist. this pull fix this issue

```
{ [ResponseError: Keyspace local_test_cassandra_restbase_T_simpleTable does not exist]
  stack: 'Error\n    at FrameReader.readError (/home/hardikj/rashomon-cassandra/node_modules/cassandra-driver/lib/readers.js:291:13)\n   
 at Parser.parseError (/home/hardikj/rashomon-cassandra/node_modules/cassandra-driver/lib/streams.js:185:45)\n    at Parser.parseBody (/home/hardikj/rashomon-cassandra/node_modules/cassandra-driver/lib/streams.js:167:19)\n    
at Parser._transform (/home/hardikj/rashomon-cassandra/node_modules/cassandra-driver/lib/streams.js:101:10)\n    at Parser.Transform._read (_stream_transform.js:179:10)\n    
at Parser.Transform._write (_stream_transform.js:167:12)\n    at doWrite (_stream_writable.js:265:12)\n    at writeOrBuffer (_stream_writable.js:252:5)\n    at Parser.Writable.write (_stream_writable.js:197:11)\n   
at Protocol.ondata (_stream_readable.js:539:20)\n    at Protocol.emit (events.js:107:17)\n    
at readableAddChunk (_stream_readable.js:162:16)\n    at Protocol.Readable.push (_stream_readable.js:125:10)\n    at Protocol.Transform.push (_stream_transform.js:140:32)\n    
at Protocol.transformChunk (/home/hardikj/rashomon-cassandra/node_modules/cassandra-driver/lib/streams.js:76:8)\n    
at Protocol._transform (/home/hardikj/rashomon-cassandra/node_modules/cassandra-driver/lib/streams.js:27:10)\n    at Protocol.Transform._read (_stream_transform.js:179:10)\n    
at Protocol.Transform._write (_stream_transform.js:167:12)\n    
at doWrite (_stream_writable.js:265:12)\n    
at writeOrBuffer (_stream_writable.js:252:5)\n    
at Protocol.Writable.write (_stream_writable.js:197:11)\n   
 at Socket.ondata (_stream_readable.js:539:20)\n    
at Socket.emit (events.js:107:17)\n    
at readableAddChunk (_stream_readable.js:162:16)\n    
at Socket.Readable.push (_stream_readable.js:125:10)\n    
at TCP.onread (net.js:514:20)\n  (event loop)\n    
at RequestHandler.send (/home/hardikj/rashomon-cassandra/node_modules/cassandra-driver/lib/request-handler.js:124:11)\n    
at Client._getPrepared (/home/hardikj/rashomon-cassandra/node_modules/cassandra-driver/lib/client.js:399:11)\n    
at /home/hardikj/rashomon-cassandra/node_modules/cassandra-driver/lib/client.js:313:12\n    
at fn (/home/hardikj/rashomon-cassandra/node_modules/async/lib/async.js:641:34)\n    
at Immediate._onImmediate (/home/hardikj/rashomon-cassandra/node_modules/async/lib/async.js:557:34)
at processImmediate [as _immediateCallback] (timers.js:374:17)',
  name: 'ResponseError',
  message: 'Keyspace local_test_cassandra_restbase_T_simpleTable does not exist',
  info: 'Represents an error message from the server',
  code: 8704,
  query: 'select * from "local_test_cassandra_restbase_T_simpleTable"."meta"' }
```
