### PR TITLE
Release restbase-mod-table-cassandra v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "dependencies": {
     "async": "0.x.x",
     "bluebird": "~2.3.10",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.0.1",
+  "version": "0.3.0",
   "dependencies": {
     "async": "0.x.x",
     "bluebird": "~2.3.10",
     "cassandra-codec": "~0.0.3",
-    "cassandra-driver": "git+https://github.com/gwicke/nodejs-driver.git#keepalive",
+    "cassandra-driver": "~1.0.3",
     "connect-busboy": "git+https://github.com/gwicke/connect-busboy.git#master",
     "coveralls": "2.11.2",
     "extend": "~2.0.0",
@@ -17,6 +17,10 @@
     "request": "2.x.x",
     "restify": "2.x.x",
     "routeswitch": "~0.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/wikimedia/restbase-mod-table-cassandra.git"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
Also switch to cassandra-driver release 1.0.3, which has our keepalive fixes.