### PR TITLE
Supply type hints to cassandra driver batch queries

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -118,7 +118,11 @@ DB.prototype._get = function (keyspace, req, consistency, table, schema) {
     var maxLimit = self.conf.maxLimit ? self.conf.maxLimit : 250;
     if (req.pageSize || req.limit > maxLimit) {
         var rows = [];
-        var options = {consistency: consistency, fetchSize: req.pageSize? req.pageSize : maxLimit};
+        var options = {
+            consistency: consistency,
+            fetchSize: req.pageSize? req.pageSize : maxLimit,
+            prepare: true
+        };
         if (req.next) {
             var token = dbu.hashKey(this.conf.salt_key);
             token = req.next.substring(0,req.next.indexOf(token)).replace(/_/g,'/').replace(/-/g,'+');
@@ -397,8 +401,13 @@ DB.prototype._put = function(keyspace, req, consistency, table ) {
     if (batch.length === 1) {
         // Single query only (no secondary indexes): no need for a batch.
         var query = batch[0];
+        queryOptions.hints = query.typeHints;
         mainUpdate = this.client.execute_p(query.query, query.params, queryOptions);
     } else {
+        // Extract typeHints from the batch
+        queryOptions.hints = batch.map(function(query) {
+            return query.typeHints;
+        });
         mainUpdate = this.client.batch_p(batch, queryOptions);
     }
 
@@ -688,35 +697,7 @@ DB.prototype._createTable = function (keyspace, schema, tableName, consistency) 
         + cassID(keyspace) + '.' + cassID(tableName) + ' (';
     for (var attr in schema.attributes) {
         var type = schema.attributes[attr];
-        cql += cassID(attr) + ' ';
-        switch (type) {
-        case 'blob': cql += 'blob'; break;
-        case 'set<blob>': cql += 'set<blob>'; break;
-        case 'decimal': cql += 'decimal'; break;
-        case 'set<decimal>': cql += 'set<decimal>'; break;
-        case 'double': cql += 'double'; break;
-        case 'set<double>': cql += 'set<double>'; break;
-        case 'float': cql += 'float'; break;
-        case 'set<float>': cql += 'set<float>'; break;
-        case 'boolean': cql += 'boolean'; break;
-        case 'set<boolean>': cql += 'set<boolean>'; break;
-        case 'int': cql += 'int'; break;
-        case 'set<int>': cql += 'set<int>'; break;
-        case 'varint': cql += 'varint'; break;
-        case 'set<varint>': cql += 'set<varint>'; break;
-        case 'string': cql += 'text'; break;
-        case 'set<string>': cql += 'set<text>'; break;
-        case 'timeuuid': cql += 'timeuuid'; break;
-        case 'set<timeuuid>': cql += 'set<timeuuid>'; break;
-        case 'uuid': cql += 'uuid'; break;
-        case 'set<uuid>': cql += 'set<uuid>'; break;
-        case 'timestamp': cql += 'timestamp'; break;
-        case 'set<timestamp>': cql += 'set<timestamp>'; break;
-        case 'json': cql += 'text'; break;
-        case 'set<json>': cql += 'set<text>'; break;
-        default: throw new Error('Invalid type ' + type
-                     + ' for attribute ' + attr);
-        }
+        cql += cassID(attr) + ' ' + dbu.schemaTypeToCQLType(type);
         if (statics[attr]) {
             cql += ' static';
         }

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -280,6 +280,42 @@ function decodeTimestamp (ts) {
     return new Date(ts).toISOString();
 }
 
+var schemaTypeToCQLTypeMap = {
+    'blob': 'blob',
+    'set<blob>': 'set<blob>',
+    'decimal': 'decimal',
+    'set<decimal>': 'set<decimal>',
+    'double': 'double',
+    'set<double>': 'set<double>',
+    'float': 'float',
+    'set<float>': 'set<float>',
+    'boolean': 'boolean',
+    'set<boolean>': 'set<boolean>',
+    'int': 'int',
+    'set<int>': 'set<int>',
+    'varint': 'varint',
+    'set<varint>': 'set<varint>',
+    'string': 'text',
+    'set<string>': 'set<text>',
+    'timeuuid': 'timeuuid',
+    'set<timeuuid>': 'set<timeuuid>',
+    'uuid': 'uuid',
+    'set<uuid>': 'set<uuid>',
+    'timestamp': 'timestamp',
+    'set<timestamp>': 'set<timestamp>',
+    'json': 'text',
+    'set<json>': 'set<text>'
+};
+
+// Map a schema type to the corresponding CQL type
+dbu.schemaTypeToCQLType = function(schemaType) {
+    var cqlType = schemaTypeToCQLTypeMap[schemaType];
+    if (!cqlType) {
+        throw new Error('Invalid schema type ' + cqlType);
+    }
+    return cqlType;
+};
+
 // Simple identity function for values that do not need conversion
 function identityConversion (val) {
     return val;
@@ -332,7 +368,7 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
     psi.conversions = {};
     for (var att in psi.attributes) {
         var type = psi.attributes[att];
-        var set_type = /set<(\w+)>/.exec(type);
+        var set_type = /^set<(\w+)>$/.exec(type);
         if (set_type) {
             // this is a set-typed attribute
             type = set_type[1];
@@ -440,8 +476,9 @@ dbu.convertRow = function convertRow (row, schema) {
  * # Section 3: CQL query generation
  */
 
-dbu.buildCondition = function buildCondition (pred) {
+dbu.buildCondition = function buildCondition (pred, schema) {
     var params = [];
+    var typeHints = [];
     var keys = [];
     var conjunctions = [];
     for (var predKey in pred) {
@@ -455,6 +492,7 @@ dbu.buildCondition = function buildCondition (pred) {
             // Default to equality
             cql += ' = ?';
             params.push(predObj);
+            typeHints.push(dbu.schemaTypeToCQLType(schema.attributes[predKey]));
             keys.push(predKey);
         } else {
             var predKeys = Object.keys(predObj);
@@ -462,16 +500,52 @@ dbu.buildCondition = function buildCondition (pred) {
                 var predOp = predKeys[0];
                 var predArg = predObj[predOp];
                 switch (predOp.toLowerCase()) {
-                case 'eq': cql += ' = ?'; params.push(predArg); keys.push(predKey); break;
-                case 'lt': cql += ' < ?'; params.push(predArg); keys.push(predKey); break;
-                case 'gt': cql += ' > ?'; params.push(predArg); keys.push(predKey); break;
-                case 'le': cql += ' <= ?'; params.push(predArg); keys.push(predKey); break;
-                case 'ge': cql += ' >= ?'; params.push(predArg); keys.push(predKey); break;
+                case 'eq':
+                    cql += ' = ?';
+                    params.push(predArg);
+                    typeHints.push(dbu.schemaTypeToCQLType(schema.attributes[predKey]));
+                    keys.push(predKey);
+                    break;
+                case 'lt':
+                    cql += ' < ?';
+                    params.push(predArg);
+                    typeHints.push(dbu.schemaTypeToCQLType(schema.attributes[predKey]));
+                    keys.push(predKey);
+                    break;
+                case 'gt':
+                    cql += ' > ?';
+                    params.push(predArg);
+                    typeHints.push(dbu.schemaTypeToCQLType(schema.attributes[predKey]));
+                    keys.push(predKey);
+                    break;
+                case 'le':
+                    cql += ' <= ?';
+                    params.push(predArg);
+                    typeHints.push(dbu.schemaTypeToCQLType(schema.attributes[predKey]));
+                    keys.push(predKey);
+                    break;
+                case 'ge':
+                    cql += ' >= ?';
+                    params.push(predArg);
+                    typeHints.push(dbu.schemaTypeToCQLType(schema.attributes[predKey]));
+                    keys.push(predKey);
+                    break;
                 case 'neq':
-                case 'ne': cql += ' != ?'; params.push(predArg); keys.push(predKey); break;
+                case 'ne':
+                    cql += ' != ?';
+                    params.push(predArg);
+                    typeHints.push(dbu.schemaTypeToCQLType(schema.attributes[predKey]));
+                    keys.push(predKey);
+                    break;
                 case 'between':
-                        cql += ' >= ?' + ' AND '; params.push(predArg[0]); keys.push(predKey);
-                        cql += dbu.cassID(predKey) + ' <= ?'; params.push(predArg[1]); keys.push(predKey);
+                        cql += ' >= ?' + ' AND ';
+                        params.push(predArg[0]);
+                        typeHints.push(dbu.schemaTypeToCQLType(schema.attributes[predKey]));
+                        keys.push(predKey);
+                        cql += dbu.cassID(predKey) + ' <= ?';
+                        params.push(predArg[1]);
+                        typeHints.push(dbu.schemaTypeToCQLType(schema.attributes[predKey]));
+                        keys.push(predKey);
                         break;
                 default: throw new Error ('Operator ' + predOp + ' not supported!');
                 }
@@ -484,7 +558,8 @@ dbu.buildCondition = function buildCondition (pred) {
     return {
         query: conjunctions.join(' AND '),
         keys: keys,
-        params: params
+        params: params,
+        typeHints: typeHints
     };
 };
 
@@ -510,6 +585,7 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
     var keys = [];
     var paramKeys = [];
     var params = [];
+    var typeHints = [];
     var placeholders = [];
     for (var key in req.attributes) {
         var val = req.attributes[key];
@@ -517,6 +593,7 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
             if (!schema.iKeyMap[key]) {
                 keys.push(key);
                 params.push(val);
+                typeHints.push(dbu.schemaTypeToCQLType(schema.attributes[key]));
                 paramKeys.push(key);
             }
             placeholders.push('?');
@@ -525,10 +602,12 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
 
     var using = '';
     var usingParams = [];
+    var usingTypeHints = [];
     var usingParamsKeys = [];
     if (req.timestamp && !req.if) {
         using = ' USING TIMESTAMP ? ';
         usingParams.push(cass.types.Long.fromNumber(Math.round(req.timestamp * 1000)));
+        usingTypeHints.push('bigint');
         usingParamsKeys.push(null);
     }
 
@@ -545,7 +624,7 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
         req.if = req.if.trim().split(/\s+/).join(' ').toLowerCase();
     }
 
-    var condRes = dbu.buildCondition(indexKVMap);
+    var condRes = dbu.buildCondition(indexKVMap, schema);
 
     var cond = '';
     if (!keys.length || req.if === 'not exists') {
@@ -557,15 +636,18 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
                 + ' (' + proj + ') values (';
         cql += placeholders.join(',') + ')' + cond + using;
         params = condRes.params.concat(params, usingParams);
+        typeHints = condRes.typeHints.concat(typeHints, usingTypeHints);
         paramKeys = condRes.keys.concat(paramKeys, usingParamsKeys);
     } else if ( keys.length ) {
         var condParams = [];
+        var condTypeHints = [];
         var condParamKeys = [];
         if (req.if) {
             cond = ' if ';
-            condResult = dbu.buildCondition(req.if);
+            condResult = dbu.buildCondition(req.if, schema);
             cond += condResult.query;
             condParams = condResult.params;
+            condTypeHints = condResult.typeHints;
             condParamKeys = condResult.keys;
         }
 
@@ -574,13 +656,18 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
                + using + ' set ' + updateProj + ' where ';
         cql += condRes.query + cond;
         params = usingParams.concat(params, condRes.params, condParams);
+        typeHints = usingTypeHints.concat(typeHints, condRes.typeHints, condTypeHints);
         paramKeys = usingParamsKeys.concat(paramKeys, condRes.keys, condParamKeys);
 
     } else {
         throw new Error("Can't Update or Insert");
     }
 
-    return {query: cql, params: dbu.convertParams(schema, paramKeys, params)};
+    return {
+        query: cql,
+        params: dbu.convertParams(schema, paramKeys, params),
+        typeHints: typeHints
+    };
 };
 
 dbu.buildGetQuery = function(keyspace, req, consistency, table, schema) {
@@ -633,7 +720,7 @@ dbu.buildGetQuery = function(keyspace, req, consistency, table, schema) {
     // Build up the condition
     if (req.attributes) {
         cql += ' where ';
-        var condResult = dbu.buildCondition(req.attributes);
+        var condResult = dbu.buildCondition(req.attributes, schema);
         cql += condResult.query;
         params = condResult.params;
         paramKeys = condResult.keys;

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ var RouteSwitch = require('routeswitch');
 var uuid = require('node-uuid');
 var makeClient = require('../lib/index');
 var dbu = require('../lib/dbutils.js');
-//TODO: change this name 
+//TODO: change this name
 var router = require('../test/test_router.js');
 
 
@@ -719,7 +719,7 @@ describe('DB backend', function() {
             });
         });
     });
-    //TODO: implement this using http handler when alternate rest-url for delete item are supported 
+    //TODO: implement this using http handler when alternate rest-url for delete item are supported
     describe('delete', function() {
         it('simple delete query', function() {
             return DB.delete('local.test.cassandra.restbase', {
@@ -759,7 +759,14 @@ describe('DB backend', function() {
                     },
                     index: [
                         { attribute: 'string', type: 'hash' },
-                    ]
+                    ],
+                    secondaryIndexes: {
+                        test: [
+                            { attribute: 'int', type: 'hash' },
+                            { attribute: 'string', type: 'range' },
+                            { attribute: 'boolean', type: 'range' }
+                        ]
+                    }
                 }
             }).then(function(response) {
                 deepEqual(response.status, 201);
@@ -795,7 +802,7 @@ describe('DB backend', function() {
             }).then(function(response) {
                 deepEqual(response.status, 201);
             });
-        }); 
+        });
         it('put', function() {
             return router.request({
                 uri: '/restbase.cassandra.test.local/sys/table/typeTable/',
@@ -885,7 +892,7 @@ describe('DB backend', function() {
                 deepEqual(response, {status:201});
             });
         });
-        it("get", function() {
+        it("get typeTable", function() {
             return router.request({
                 uri: '/restbase.cassandra.test.local/sys/table/typeTable/',
                 method: 'get',
@@ -934,6 +941,21 @@ describe('DB backend', function() {
                 }]);
             });
         });
+        it("get typeTable index", function() {
+            return router.request({
+                uri: '/restbase.cassandra.test.local/sys/table/typeTable/',
+                method: 'get',
+                body: {
+                    table: "typeTable",
+                    index: 'test',
+                    proj: ['int']
+                }
+            })
+            .then(function(response){
+                response.body.items[0].int = 1;
+                response.body.items[1].int = -1;
+            });
+        });
         it("get sets", function() {
             return router.request({
                 uri: '/restbase.cassandra.test.local/sys/table/typeSetsTable/',
@@ -948,7 +970,7 @@ describe('DB backend', function() {
             .then(function(response){
                 // note: Cassandra orders sets, so the expected rows are
                 // slightly different than the original, supplied ones
-                response.body.items[0].float = [roundDecimal(response.body.items[0].float[0]), 
+                response.body.items[0].float = [roundDecimal(response.body.items[0].float[0]),
                                                 roundDecimal(response.body.items[0].float[1])];
                 deepEqual(response.body.items, [{
                     string: 'string',


### PR DESCRIPTION
Build up & pass along type hints, so that batch queries with ambiguous numeric
types work despite the cassandra driver's lack of prepare support in batches.
In practice, this means that tables containing ints or floats now work even if
they have secondary indexes defined.

There is still a warning emitted from the cassandra driver for some reason,
but the actual requests go through as verified by the following read tests.

Bug: https://phabricator.wikimedia.org/T88690