### PR TITLE
Small performance & correctness tweaks

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -316,10 +316,6 @@ dbu.schemaTypeToCQLType = function(schemaType) {
     return cqlType;
 };
 
-// Simple identity function for values that do not need conversion
-function identityConversion (val) {
-    return val;
-}
 
 /**
  * Generates read/write conversion functions for set-typed attributes
@@ -329,16 +325,23 @@ function identityConversion (val) {
  */
 function generateSetConvertor (convObj) {
     if (!convObj) {
-        return { write: identityConversion, read: identityConversion };
+        return;
     }
-    return {
-        write: function (valArray) {
-            return valArray.map(convObj.write);
-        },
-        read: function (valArray) {
-            return valArray.map(convObj.read);
-        }
+    var res = {
+        write: null,
+        read: null
     };
+    if (convObj.write) {
+        res.write = function (valArray) {
+            return valArray.map(convObj.write);
+        };
+    }
+    if (convObj.read) {
+        res.read = function (valArray) {
+            return valArray.map(convObj.read);
+        };
+    }
+    return res;
 }
 
 dbu.conversions = {
@@ -346,7 +349,7 @@ dbu.conversions = {
     decimal: { write: codec.encodeDecimal, read: codec.decodeDecimal },
     timestamp: { write: encodeTimestamp, read: decodeTimestamp },
     json: { write: JSON.stringify, read: JSON.parse },
-    blob: { write: encodeBlob, read: identityConversion }
+    blob: { write: encodeBlob, read: null }
 };
 
 /*
@@ -461,14 +464,11 @@ dbu.convertParams = function convertParams (schema, keys, params) {
  * @returns {Row} the row with converted attribute values
  */
 dbu.convertRow = function convertRow (row, schema) {
-    if (!(row && schema && schema.conversions)) {
-        return row;
-    }
-    for (var att in row) {
-        if (row[att] && schema.conversions[att] && schema.conversions[att].read) {
+    Object.keys(row).forEach(function(att) {
+        if (row[att] !== null && schema.conversions[att] && schema.conversions[att].read) {
             row[att] = schema.conversions[att].read(row[att]);
         }
-    }
+    });
     return row;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "dependencies": {
     "async": "0.x.x",
     "bluebird": "~2.3.10",


### PR DESCRIPTION
- Apply type conversions for all non-null values, not just to truthy values
- Replace identityConversion with null, saves one function call for buffers
  (common)
- Simplify convertRow: use Object.keys.forEach() instead of for (var i in
  obj), remove unnecessary arg checks