### PR TITLE
Support for specifying the localDc parameter

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -608,11 +608,12 @@ DB.prototype.createTable = function (reverseDomain, req) {
     //
     // Always use NetworkTopologyStrategy with default 'datacenter1' for easy
     // extension to cross-DC replication later.
-    var replicationOptions = "{ 'class': 'NetworkTopologyStrategy', 'datacenter1': 3 }";
+    var localDc = this.conf.localDc;
+    var replicationOptions = "{ 'class': 'NetworkTopologyStrategy', '" + localDc + "': 3 }";
 
     if (req.options) {
         if (req.options.durability === 'low') {
-            replicationOptions = "{ 'class': 'NetworkTopologyStrategy', 'datacenter1': 1 }";
+            replicationOptions = "{ 'class': 'NetworkTopologyStrategy', '" + localDc + "': 1 }";
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,11 @@ function makeClient (options) {
     var conf = options.conf;
     clientOpts.keyspace = conf.keyspace || 'system';
     clientOpts.contactPoints = conf.hosts;
+    // Default to 'datacenter1'
+    if (!conf.localDc) { conf.localDc = 'datacenter1'; }
+    // See http://www.datastax.com/drivers/nodejs/1.0/module-policies_loadBalancing-DCAwareRoundRobinPolicy.html
+    clientOpts.loadBalancing = new cass.policies
+        .loadBalancing.DCAwareRoundRobinPolicy(conf.localDc);
     // Also see
     // http://www.datastax.com/documentation/developer/nodejs-driver/1.0/common/drivers/reference/clientOptions.html
     clientOpts.reconnection = new cass.policies


### PR DESCRIPTION
- Important for multi-DC operation, so that localQuorum etc knows what is
  actually local
- Create tables in localDc by default. In the longer term, this should
  probably load the cluster state from system.local & system.peers instead.