### PR TITLE
Add ability to share column families between domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,6 @@ var util = require('util');
 // TODO: move to separate package!
 var spec = yaml.safeLoad(fs.readFileSync(__dirname + '/table.yaml'));
 
-function reverseDomain (domain) {
-    return domain.toLowerCase().split('.').reverse().join('.');
-}
-
 function RBCassandra (options) {
     this.options = options;
     this.conf = options.conf;
@@ -36,7 +32,7 @@ RBCassandra.prototype.createTable = function (rb, req) {
     var store = this.store;
     // XXX: decide on the interface
     req.body.table = req.params.table;
-    var domain = reverseDomain(req.params.domain);
+    var domain = req.params.domain;
 
     // check if the domains table exists
     return store.createTable(domain, req.body)
@@ -82,7 +78,7 @@ RBCassandra.prototype.get = function (rb, req) {
             limit: 10
         };
     }
-    var domain = reverseDomain(req.params.domain);
+    var domain = req.params.domain;
     return this.store.get(domain, req.body)
     .then(function(res) {
         return {
@@ -106,7 +102,7 @@ RBCassandra.prototype.get = function (rb, req) {
 
 // Update a table
 RBCassandra.prototype.put = function (rb, req) {
-    var domain = reverseDomain(req.params.domain);
+    var domain = req.params.domain;
     // XXX: Use the path to determine the primary key?
     return this.store.put(domain, req.body)
     .then(function(res) {
@@ -129,7 +125,7 @@ RBCassandra.prototype.put = function (rb, req) {
 };
 
 RBCassandra.prototype.dropTable = function (rb, req) {
-    var domain = reverseDomain(req.params.domain);
+    var domain = req.params.domain;
     return this.store.dropTable(domain, req.params.table)
     .then(function(res) {
         return {

--- a/lib/db.js
+++ b/lib/db.js
@@ -84,7 +84,7 @@ DB.prototype._makeInternalRequest = function (domain, table, query, consistency)
                 // Need to parse the JSON manually here as we are using the
                 // internal _get(), which doesn't apply transforms.
                 var schema = JSON.parse(res.items[0].value);
-                req.schema = dbu.makeSchemaInfo(schema);
+                self.schemaCache[schemaCacheKey] = req.schema = dbu.makeSchemaInfo(schema);
             }
             return req;
         }, function(err) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -8,6 +8,7 @@ var dbu = require('./dbutils');
 var cassID = dbu.cassID;
 var secIndexes = require('./secondaryIndexes');
 
+
 function DB (client, options) {
     this.conf = options.conf;
     this.log = options.log;
@@ -22,6 +23,88 @@ function DB (client, options) {
     // cache keyspace -> schema
     this.schemaCache = {};
 }
+
+/**
+ * Wrap common internal request state
+ */
+function InternalRequest (opts) {
+    this.domain = opts.domain;
+    this.table = opts.table;
+    this.keyspace = opts.keyspace || dbu.keyspaceName(opts.domain, opts.table);
+    this.query = opts.query || null;
+    this.consistency = opts.consistency;
+    this.schema = opts.schema || null;
+    this.columnfamily = opts.columnfamily || 'data';
+}
+
+/**
+ * Construct a new InternalRequest based on an existing one, optionally
+ * overriding existing properties.
+ */
+InternalRequest.prototype.extend = function(opts) {
+    var req = new InternalRequest(this);
+    Object.keys(opts).forEach(function(key) {
+        req[key] = opts[key];
+    });
+    return req;
+};
+
+DB.prototype._makeInternalRequest = function (domain, table, query, consistency) {
+    var self = this;
+    consistency = consistency || this.defaultConsistency;
+    if (query.consistency && query.consistency in {all:1, localQuorum:1}) {
+        consistency = cass.types.consistencies[query.consistency];
+    }
+    var req = new InternalRequest({
+        domain: domain,
+        table: table,
+        query: query,
+        consistency: consistency,
+        columnfamily: 'data'
+    });
+    var schemaCacheKey = JSON.stringify([req.keyspace, domain]);
+    req.schema = this.schemaCache[schemaCacheKey];
+    if (req.schema) {
+        return Promise.resolve(req);
+    } else {
+        var schemaQuery = {
+            attributes: {
+                key: 'schema'
+            },
+            limit: 1
+        };
+        var schemaReq = req.extend({
+            query: schemaQuery,
+            columnfamily: 'meta',
+            schema: this.infoSchemaInfo
+        });
+        return this._get(schemaReq)
+        .then(function(res) {
+            if (res.items.length) {
+                // Need to parse the JSON manually here as we are using the
+                // internal _get(), which doesn't apply transforms.
+                var schema = JSON.parse(res.items[0].value);
+                req.schema = dbu.makeSchemaInfo(schema);
+            }
+            return req;
+        }, function(err) {
+            // Check if the keyspace & meta column family exists
+            return self.client.execute_p('SELECT columnfamily_name FROM '
+                + 'system.schema_columnfamilies WHERE keyspace_name=? '
+                + 'and columnfamily_name=?', [req.keyspace, 'meta'])
+            .then(function (res) {
+                if (res && res.rows.length === 0) {
+                    // meta column family doesn't exist yet
+                    return req;
+                } else {
+                    // re-throw error
+                    throw err;
+                }
+            });
+        });
+    }
+};
+
 
 // Info table schema
 DB.prototype.infoSchema = dbu.validateAndNormalizeSchema({
@@ -40,160 +123,34 @@ DB.prototype.infoSchema = dbu.validateAndNormalizeSchema({
 
 DB.prototype.infoSchemaInfo = dbu.makeSchemaInfo(DB.prototype.infoSchema);
 
-
-DB.prototype.getSchema = function (reverseDomain, tableName) {
-    var keyspace = dbu.keyspaceName(reverseDomain, tableName);
-
-    // consistency
-    var consistency = this.defaultConsistency;
-    var query = {
-        attributes: {
-            key: 'schema'
-        }
-    };
-    return this._getSchema(keyspace, consistency);
-};
-
-DB.prototype._getSchema = function (keyspace, consistency) {
+DB.prototype.get = function (domain, query) {
     var self = this;
-    var query = {
-        attributes: {
-            key: 'schema'
-        },
-        limit: 1
-    };
-    return this._get(keyspace, query, consistency, 'meta', this.infoSchemaInfo)
-    .then(function(res) {
-        if (res.items.length) {
-            var schema = JSON.parse(res.items[0].value);
-            return dbu.makeSchemaInfo(schema);
-        } else {
-            return null;
-        }
-    }, function(err) {
-        // Check if the keyspace & meta column family exists
-        return self.client.execute_p('SELECT columnfamily_name FROM '
-            + 'system.schema_columnfamilies WHERE keyspace_name=? '
-            + 'and columnfamily_name=?', [keyspace, 'meta'])
-        .then(function (res) {
-            if (res && res.rows.length === 0) {
-                // meta column family doesn't exist yet
-                return null;
-            } else {
-                // re-throw error
-                throw err;
-            }
+    return this._makeInternalRequest(domain, query.table, query)
+    .then(function(req) {
+        return self._get(req)
+        .then(function(res) {
+            // Apply value conversions
+            res.items = dbu.convertRows(res.items, req.schema);
+            return res;
         });
     });
 };
 
-DB.prototype.get = function (reverseDomain, req) {
-    var self = this;
-    var keyspace = dbu.keyspaceName(reverseDomain, req.table);
-
-    // consistency
-    var consistency = this.defaultConsistency;
-    if (req.consistency && req.consistency in {all:1, localQuorum:1}) {
-        consistency = cass.types.consistencies[req.consistency];
-    }
-
-    var schema = this.schemaCache[keyspace];
-    if (!schema) {
-        return this._getSchema(keyspace, this.defaultConsistency)
-        .then(function(schema) {
-            //console.log('schema', schema);
-            self.schemaCache[keyspace] = schema;
-            return self._get(keyspace, req, consistency, 'data', schema)
-            .then(function(res) {
-                // Apply value conversions
-                dbu.convertRows(res.items, schema);
-                return res;
-            });
-        });
-    } else {
-        return this._get(keyspace, req, consistency, 'data', schema)
-        .then(function(res) {
-            // Apply value conversions
-            dbu.convertRows(res.items, schema);
-            return res;
-        });
-    }
-};
-
-DB.prototype._get = function (keyspace, req, consistency, table, schema) {
+DB.prototype._get = function (req) {
     var self = this;
 
-    if (!table) {
-        table = 'data';
+    if (!req.schema) {
+        throw new Error("restbase-cassandra: No schema for " + req.keyspace
+                + ', table: ' + req.columnfamily);
     }
 
-    if (!schema) {
-        throw new Error("restbase-cassandra: No schema for " + keyspace
-                + ', table: ' + table);
+    if (!req.schema.iKeyMap) {
+        self.log('error/cassandra/no_iKeyMap', req.schema);
     }
+    var buildResult = dbu.buildGetQuery(req);
 
-    if (!schema.iKeyMap) {
-        self.log('error/cassandra/no_iKeyMap', schema);
-    }
-    var buildResult = dbu.buildGetQuery(keyspace, req, consistency, table, schema);
-
-    // Index queries are currently handled in buildGetQuery. See
-    // https://phabricator.wikimedia.org/T78722 for secondary index TODOs.
-    //if (req.index) {
-    //    return this._getSecondaryIndex(keyspace, req, consistency, table, buildResult);
-    //}
-
-    var maxLimit = self.conf.maxLimit ? self.conf.maxLimit : 250;
-    if (req.pageSize || req.limit > maxLimit) {
-        var rows = [];
-        var options = {
-            consistency: consistency,
-            fetchSize: req.pageSize? req.pageSize : maxLimit,
-            prepare: true
-        };
-        if (req.next) {
-            var token = dbu.hashKey(this.conf.salt_key);
-            token = req.next.substring(0,req.next.indexOf(token)).replace(/_/g,'/').replace(/-/g,'+');
-            options.pageState = new Buffer(token, 'base64');
-        }
-        return new P(function(resolve, reject) {
-            try {
-                self.client.eachRow(buildResult.query, buildResult.params, options,
-                    function(n, result){
-                        dbu.convertRow(result, schema);
-                        if (!result._del) {
-                            rows.push(result);
-                        }
-                    }, function(err, result){
-                        if (err) {
-                            reject(err);
-                        } else {
-                            var token = null;
-                            if (result.meta.pageState) {
-                                token = result.meta.pageState.toString('base64')
-                                    .replace(/\//g,'_').replace(/\+/g,'-')
-                                    // FIXME: use proper hashing - this is
-                                    // nonsense.
-                                    // See  https://phabricator.wikimedia.org/T85640
-                                    + dbu.hashKey(self.conf.salt_key
-                                            && self.conf.salt_key.toString()
-                                            || 'deadbeef');
-                            }
-                            resolve({
-                                items: rows,
-                                next: token
-                            });
-                       }
-                    }
-                );
-            } catch (e) {
-                reject (e);
-            }
-        });
-    }
-
-    return self.client.execute_p(buildResult.query, buildResult.params,
-            {consistency: consistency, prepare: true})
+    return self.client.execute_p(buildResult.cql, buildResult.params,
+            {consistency: req.consistency, prepare: true})
     .then(function(result){
         return {
             items: result.rows.filter(function(row) {
@@ -201,83 +158,144 @@ DB.prototype._get = function (keyspace, req, consistency, table, schema) {
             })
         };
     });
+
+    // Index queries are currently handled in buildGetQuery. See
+    // https://phabricator.wikimedia.org/T78722 for secondary index TODOs.
+    //if (req.index) {
+    //    return this._getSecondaryIndex(keyspace, req, consistency, table, buildResult);
+    //}
+
+    // Paging request: Currently disabled until this is made safe & sane.
+    // See https://phabricator.wikimedia.org/T85640.
+    //
+    //var maxLimit = self.conf.maxLimit ? self.conf.maxLimit : 250;
+    //if (req.pageSize || req.limit > maxLimit) {
+    //    var rows = [];
+    //    var options = {
+    //        consistency: consistency,
+    //        fetchSize: req.pageSize? req.pageSize : maxLimit,
+    //        prepare: true
+    //    };
+    //    if (req.next) {
+    //        var token = dbu.hashKey(this.conf.salt_key);
+    //        token = req.next.substring(0,req.next.indexOf(token)).replace(/_/g,'/').replace(/-/g,'+');
+    //        options.pageState = new Buffer(token, 'base64');
+    //    }
+    //    return new P(function(resolve, reject) {
+    //        try {
+    //            self.client.eachRow(buildResult.cql, buildResult.params, options,
+    //                function(n, result){
+    //                    dbu.convertRow(result, req.schema);
+    //                    if (!result._del) {
+    //                        rows.push(result);
+    //                    }
+    //                }, function(err, result){
+    //                    if (err) {
+    //                        reject(err);
+    //                    } else {
+    //                        var token = null;
+    //                        if (result.meta.pageState) {
+    //                            token = result.meta.pageState.toString('base64')
+    //                                .replace(/\//g,'_').replace(/\+/g,'-')
+    //                                // FIXME: use proper hashing - this is
+    //                                // nonsense.
+    //                                // See  https://phabricator.wikimedia.org/T85640
+    //                                + dbu.hashKey(self.conf.salt_key
+    //                                        && self.conf.salt_key.toString()
+    //                                        || 'deadbeef');
+    //                        }
+    //                        resolve({
+    //                            items: rows,
+    //                            next: token
+    //                        });
+    //                   }
+    //                }
+    //            );
+    //        } catch (e) {
+    //            reject (e);
+    //        }
+    //    });
+    //}
+
 };
 
 /*
     Handler for request GET requests on secondary indexes.
+    This is currently not used. TODO: fix.
 */
-DB.prototype._getSecondaryIndex = function(keyspace, req, consistency, table, buildResult){
-
-    // TODO: handle '_tid' cases
-    var self = this;
-    return self.client.execute_p(buildResult.query, buildResult.params,
-            {consistency: consistency, prepare: true})
-    .then(function(results) {
-        var queries = [];
-        var cachedSchema = self.schemaCache[keyspace];
-
-        // convert the result values
-        results.rows.forEach(function (row) {
-            dbu.convertRow(row, cachedSchema);
-        });
-
-        var newReq = {
-            table: table,
-            attributes: {},
-            limit: req.limit + Math.ceil(req.limit/4)
-        };
-
-        // build main data queries
-        for ( var rowno in results.rows ) {
-            for ( var attr in cachedSchema.iKeyMap ) {
-                newReq.attributes[attr] = results.rows[rowno][attr];
-            }
-            queries.push(dbu.buildGetQuery(keyspace, newReq, consistency, table, cachedSchema));
-            newReq.attributes = {};
-        }
-
-        // prepare promises for batch execution
-        var batchPromises = [];
-        queries.forEach(function(item) {
-            batchPromises.push(self.client.execute_p(item.query, item.params,
-                        item.options || {consistency: consistency, prepare: true}));
-        });
-
-        // execute batch and check if limit is fulfilled
-        return P.all(batchPromises).then(function(batchResults){
-            var finalRows = [];
-            batchResults.forEach(function(item){
-                if (finalRows.length < req.limit) {
-                    finalRows.push(dbu.convertRow(item.rows[0], cachedSchema));
-                }
-            });
-            return [finalRows, results.rows[rowno]];
-        });
-    })
-    .then(function(rows){
-        //TODO: handle case when limit > no of entries in table
-        if (rows[0].length<req.limit) {
-            return self.indexReads(keyspace, req, consistency, table, rows[1], rows[0]);
-        }
-        return rows[0];
-    }).then(function(rows){
-        // hide the columns property added by node-cassandra-cql
-        // XXX: submit a patch to avoid adding it in the first place
-        for (var row in rows) {
-            row.columns = undefined;
-        }
-        return {
-            items: rows
-        };
-    });
-};
+//DB.prototype._getSecondaryIndex = function(keyspace, domain, req,
+//        consistency, table, buildResult){
+//
+//    // TODO: handle '_tid' cases
+//    var self = this;
+//    return self.client.execute_p(buildResult.cql, buildResult.params,
+//            {consistency: consistency, prepare: true})
+//    .then(function(results) {
+//        var queries = [];
+//        var cachedSchema = self.schemaCache[keyspace];
+//
+//        // convert the result values
+//        results.rows.forEach(function (row) {
+//            dbu.convertRow(row, cachedSchema);
+//        });
+//
+//        var newReq = {
+//            table: table,
+//            attributes: {},
+//            limit: req.limit + Math.ceil(req.limit/4)
+//        };
+//
+//        // build main data queries
+//        for ( var rowno in results.rows ) {
+//            for ( var attr in cachedSchema.iKeyMap ) {
+//                newReq.attributes[attr] = results.rows[rowno][attr];
+//            }
+//            queries.push(dbu.buildGetQuery(keyspace, domain, newReq, consistency, table, cachedSchema));
+//            newReq.attributes = {};
+//        }
+//
+//        // prepare promises for batch execution
+//        var batchPromises = [];
+//        queries.forEach(function(item) {
+//            batchPromises.push(self.client.execute_p(item.cql, item.params,
+//                        item.options || {consistency: consistency, prepare: true}));
+//        });
+//
+//        // execute batch and check if limit is fulfilled
+//        return P.all(batchPromises).then(function(batchResults){
+//            var finalRows = [];
+//            batchResults.forEach(function(item){
+//                if (finalRows.length < req.limit) {
+//                    finalRows.push(dbu.convertRow(item.rows[0], cachedSchema));
+//                }
+//            });
+//            return [finalRows, results.rows[rowno]];
+//        });
+//    })
+//    .then(function(rows){
+//        //TODO: handle case when limit > no of entries in table
+//        if (rows[0].length<req.limit) {
+//            return self.indexReads(keyspace, domain, req, consistency, table, rows[1], rows[0]);
+//        }
+//        return rows[0];
+//    }).then(function(rows){
+//        // hide the columns property added by node-cassandra-cql
+//        // XXX: submit a patch to avoid adding it in the first place
+//        for (var row in rows) {
+//            row.columns = undefined;
+//        }
+//        return {
+//            items: rows
+//        };
+//    });
+//};
 
 /*
     Fetch index entries and compare them against data row for false positives
     - if limit is fullfilled return
     - else fetch more entries and compare again
 */
-DB.prototype.indexReads = function(keyspace, req, consistency, table, startKey, finalRows) {
+DB.prototype.indexReads = function(keyspace, domain, req, consistency, table, startKey, finalRows) {
 
     // create new index query
     var newIndexReq = {
@@ -312,7 +330,7 @@ DB.prototype.indexReads = function(keyspace, req, consistency, table, startKey, 
     var lastrow;
     return new P(function(resolve, reject){
         // stream  the main data table
-        var stream = self.client.stream(buildResult.query, buildResult.params,
+        var stream = self.client.stream(buildResult.cql, buildResult.params,
                     {
                         autoPage: true,
                         fetchSize: req.limit + Math.ceil(req.limit/4),
@@ -338,7 +356,7 @@ DB.prototype.indexReads = function(keyspace, req, consistency, table, startKey, 
                 if (finalRows.length<req.limit) {
                     return self.indexReads(keyspace, req, consistency, table, lastrow, finalRows);
                 } else {
-                    return self.client.execute_p(item.query, item.params,
+                    return self.client.execute_p(item.cql, item.params,
                             item.options || {consistency: consistency, prepare: true})
                     .then(function(results){
                         if (finalRows.length < req.limit) {
@@ -351,56 +369,30 @@ DB.prototype.indexReads = function(keyspace, req, consistency, table, startKey, 
     });
 };
 
-DB.prototype.put = function (reverseDomain, req) {
-    var keyspace = dbu.keyspaceName(reverseDomain, req.table);
-
-
-    // consistency
-    var consistency = this.defaultConsistency;
-    if (req.consistency && req.consistency in {all:1, localQuorum:1}) {
-        consistency = cass.types.consistencies[req.consistency];
-    }
-
-    // Get the type info for the table & verify types & ops per index
-    var self = this;
-    if (!this.schemaCache[keyspace]) {
-        return this._getSchema(keyspace, this.defaultConsistency)
-        .then(function(schema) {
-            self.schemaCache[keyspace] = schema;
-            return self._put(keyspace, req, consistency);
-        });
-    } else {
-        return this._put(keyspace, req, consistency);
-    }
+DB.prototype.put = function (domain, query) {
+    return this._makeInternalRequest(domain, query.table, query)
+    .bind(this)
+    .then(this._put);
 };
 
 
-DB.prototype._put = function(keyspace, req, consistency, table ) {
+DB.prototype._put = function(req) {
     var self = this;
 
-    if (!table) {
-        table = 'data';
-    }
-
-    var schema;
-    if (table === 'meta') {
-        schema = this.infoSchemaInfo;
-    } else if ( table === "data" ) {
-        schema = this.schemaCache[keyspace];
-    }
-
-    if (!schema) {
+    if (!req.schema) {
         throw new Error('Table not found!');
     }
+    var schema = req.schema;
+    var query = req.query;
 
-    var tid = req.attributes[schema.tid];
+    var tid = query.attributes[schema.tid];
     if (!tid) {
-        req.attributes[schema.tid] = TimeUuid.now();
+        query.attributes[schema.tid] = TimeUuid.now();
     } else if (tid.constructor === String) {
-        req.attributes[schema.tid] = TimeUuid.fromString(req.attributes[schema.tid]);
+        query.attributes[schema.tid] = TimeUuid.fromString(query.attributes[schema.tid]);
     }
 
-    req.timestamp = dbu.tidNanoTime(req.attributes[schema.tid]);
+    query.timestamp = dbu.tidNanoTime(query.attributes[schema.tid]);
 
     // insert into secondary Indexes first
     var batch = [];
@@ -410,22 +402,32 @@ DB.prototype._put = function(keyspace, req, consistency, table ) {
             if (!secondarySchema) {
                 throw new Error('Table not found!');
             }
-            //if (req.attributes.uri) { console.log(req.attributes.uri, req.timestamp); }
-            batch.push(dbu.buildPutQuery(req, keyspace, dbu.idxTable(idx), secondarySchema));
+            //if (query.attributes.uri) { console.log(query.attributes.uri, query.timestamp); }
+            var idxReq = req.extend({
+                columnfamily: dbu.idxColumnFamily(idx),
+                schema: secondarySchema
+            });
+            batch.push(dbu.buildPutQuery(idxReq));
         }
     }
 
-    batch.push(dbu.buildPutQuery(req, keyspace, table, schema));
+    batch.push(dbu.buildPutQuery(req));
 
     //console.log(batch, schema);
-    var queryOptions = {consistency: consistency, prepare: true};
+    var queryOptions = {consistency: req.consistency, prepare: true};
     var mainUpdate;
     if (batch.length === 1) {
         // Single query only (no secondary indexes): no need for a batch.
-        var query = batch[0];
-        mainUpdate = this.client.execute_p(query.query, query.params, queryOptions);
+        var queryInfo = batch[0];
+        mainUpdate = this.client.execute_p(queryInfo.cql, queryInfo.params, queryOptions);
     } else {
-        mainUpdate = this.client.batch_p(batch, queryOptions);
+        var driverBatch = batch.map(function(queryInfo) {
+            return {
+                query: queryInfo.cql,
+                params: queryInfo.params
+            };
+        });
+        mainUpdate = this.client.batch_p(driverBatch, queryOptions);
     }
 
     return mainUpdate
@@ -433,7 +435,7 @@ DB.prototype._put = function(keyspace, req, consistency, table ) {
     .then(function(result) {
         // Kick off asynchronous local index rebuild
         if (schema.secondaryIndexes) {
-            self._rebuildIndexes(keyspace, req, schema, 3)
+            self._rebuildIndexes(req, 3)
             .catch(function(err) {
                 self.log('error/cassandra/rebuildIndexes', err);
             });
@@ -456,15 +458,17 @@ DB.prototype._put = function(keyspace, req, consistency, table ) {
  *   - walk results in ascending order and diff each row vs. preceding row
  *      - if diff: for each index affected by that diff, update _deleted for old value
  *        using that revision's TIMESTAMP.
- * @param {string} keyspace
- * @param {object} req, the original update request; pass in empty attributes
- *        to match / rebuild all entries
- * @param {object} schema, the table schema
+ * @param {object} InternalRequest; pass in an empty query to match / rebuild
+ *        all entries
+ * @param {number} limit [optional] The maximum number of entries to include in
+ *      the index update.
  * @param {array} (optional) indexes, an array of index names to update;
- *        default: all indexes in the schema
+ *      Default: all indexes in the schema
  */
-DB.prototype._rebuildIndexes = function (keyspace, req, schema, limit, indexes) {
+DB.prototype._rebuildIndexes = function (req, limit, indexes) {
     var self = this;
+    var schema = req.schema;
+    var query = req.query;
     if (!indexes) {
         indexes = Object.keys(schema.secondaryIndexes);
     }
@@ -474,8 +478,8 @@ DB.prototype._rebuildIndexes = function (keyspace, req, schema, limit, indexes) 
         var tidKey = schema.tid;
 
         // Build a new request for the main data table
-        var dataReq = {
-            table: req.table,
+        var dataQuery = {
+            table: req.query.table,
             attributes: {},
             proj: []
         };
@@ -484,8 +488,8 @@ DB.prototype._rebuildIndexes = function (keyspace, req, schema, limit, indexes) 
         // that's empty, the entire index (within the numerical limits) will be updated.
         schema.iKeys.forEach(function(att) {
             if (att !== tidKey) {
-                dataReq.attributes[att] = req.attributes[att];
-                dataReq.proj.push(att);
+                dataQuery.attributes[att] = req.query.attributes[att];
+                dataQuery.proj.push(att);
             }
         });
 
@@ -495,7 +499,7 @@ DB.prototype._rebuildIndexes = function (keyspace, req, schema, limit, indexes) 
             // console.log(idx, JSON.stringify(schema.secondaryIndexes));
             Object.keys(schema.attributeIndexes).forEach(function(att) {
                 if (!schema.iKeyMap[att] && !secondaryKeySet[att]) {
-                    dataReq.proj.push(att);
+                    dataQuery.proj.push(att);
                     secondaryKeySet[att] = true;
                 }
             });
@@ -503,27 +507,28 @@ DB.prototype._rebuildIndexes = function (keyspace, req, schema, limit, indexes) 
         var secondaryKeys = Object.keys(secondaryKeySet);
         // Include the data table's _del column, so that we can deal with
         // deleted rows there
-        dataReq.proj.push('_del');
+        dataQuery.proj.push('_del');
         if (!secondaryKeySet[tidKey]) {
-            dataReq.proj.push(tidKey);
+            dataQuery.proj.push(tidKey);
         }
 
         // XXX: handle the case where reqTid is not defined!
-        var reqTid = req.attributes[schema.tid];
+        var reqTid = query.attributes[schema.tid];
         var reqTime = dbu.tidNanoTime(reqTid);
 
         // Clone the query, and create le & gt variants
-        var newerDataReq = extend(true, {}, dataReq);
+        var newerDataQuery = extend(true, {}, dataQuery);
         // 1) select one newer index entry
-        newerDataReq.attributes[schema.tid] = { 'ge': reqTid };
-        newerDataReq.order = {};
-        newerDataReq.order[schema.tid] = 'asc'; // select sibling entries
-        newerDataReq.limit = 2; // data entry + newer entry
-        var newerRebuild = self._get(keyspace, newerDataReq,
-                self.defaultConsistency, 'data', schema)
+        newerDataQuery.attributes[schema.tid] = { 'ge': reqTid };
+        newerDataQuery.order = {};
+        newerDataQuery.order[schema.tid] = 'asc'; // select sibling entries
+        newerDataQuery.limit = 2; // data entry + newer entry
+        var newerRebuildRequest = req.extend({
+            query: newerDataQuery
+        });
+        var newerRebuild = self._get(newerRebuildRequest)
         .then(function(res) {
-            var newerRebuilder = new secIndexes.IndexRebuilder(self, keyspace,
-                    schema, secondaryKeys, reqTime);
+            var newerRebuilder = new secIndexes.IndexRebuilder(self, req, secondaryKeys, reqTime);
             // XXX: handle the case where reqTid is not defined?
             for (var i = res.items.length - 1; i >= 0; i--) {
                 // Process rows in reverse chronological order
@@ -534,8 +539,8 @@ DB.prototype._rebuildIndexes = function (keyspace, req, schema, limit, indexes) 
 
         var mainRebuild = new P(function(resolve, reject) {
             try {
-                dataReq.attributes[schema.tid] = {'le': reqTid};
-                dataReq.limit = limit; // typically something around 3, or unlimited
+                dataQuery.attributes[schema.tid] = {'le': reqTid};
+                dataQuery.limit = limit; // typically something around 3, or unlimited
                 var reqOptions = {
                     prepare : true,
                     fetchSize : 1000,
@@ -543,10 +548,13 @@ DB.prototype._rebuildIndexes = function (keyspace, req, schema, limit, indexes) 
                 };
                 // Traverse the bulk of the data, in timestamp descending order
                 // (reverse chronological)
-                var dataQuery = dbu.buildGetQuery(keyspace, dataReq, consistency, 'data', schema);
-                var mainRebuilder = new secIndexes.IndexRebuilder(self, keyspace,
-                        schema, secondaryKeys, reqTime);
-                self.client.eachRow(dataQuery.query, dataQuery.params, reqOptions,
+                var dataGetReq = req.extend({
+                    query: dataQuery,
+                    columnfamily: 'data'
+                });
+                var dataGetInfo = dbu.buildGetQuery(dataGetReq);
+                var mainRebuilder = new secIndexes.IndexRebuilder(self, req, secondaryKeys, reqTime);
+                self.client.eachRow(dataGetInfo.cql, dataGetInfo.params, reqOptions,
                     // row callback
                     mainRebuilder.handleRow.bind(mainRebuilder),
                     // end callback
@@ -570,65 +578,42 @@ DB.prototype._rebuildIndexes = function (keyspace, req, schema, limit, indexes) 
 };
 
 
-DB.prototype.delete = function (reverseDomain, req) {
-    var keyspace = dbu.keyspaceName(reverseDomain, req.table);
-
-    // consistency
-    var consistency = this.defaultConsistency;
-    if (req.consistency && req.consistency in {all:1, localQuorum:1}) {
-        consistency = cass.types.consistencies[req.consistency];
-    }
-    return this._delete(keyspace, req, consistency);
+DB.prototype.delete = function (domain, query) {
+    return this._makeInternalRequest(domain, query.table, query)
+    .bind(this)
+    .then(this._delete);
 };
 
-DB.prototype._delete = function (keyspace, req, consistency, table) {
+DB.prototype._delete = function (req) {
 
-    if (!table) {
-        table = 'data';
-    }
     // Mark _del with current timestamp and update the row.
-    req.attributes._del = TimeUuid.now();
+    req.query.attributes._del = TimeUuid.now();
 
-    var self = this;
-    if (!this.schemaCache[keyspace]) {
-        return this._getSchema(keyspace, this.defaultConsistency)
-        .then(function(schema) {
-            self.schemaCache[keyspace] = schema;
-            return self._put(keyspace, req, consistency);
-        });
-    } else {
-        return this._put(keyspace, req, consistency);
-    }
+    return this._put(req);
 };
 
-DB.prototype.createTable = function (reverseDomain, req) {
+DB.prototype.createTable = function (domain, query) {
     var self = this;
-    if (!req.table) {
+    if (!query.table) {
         throw new Error('Table name required.');
     }
-    var keyspace = dbu.keyspaceName(reverseDomain, req.table);
 
-    // consistency
-    var consistency = self.defaultConsistency;
-    if (req.consistency && req.consistency in {all:1, localQuorum:1}) {
-        consistency = cass.types.consistencies[req.consistency];
-    }
-
-    return this._getSchema(keyspace, consistency)
+    return this._makeInternalRequest(domain, query.table, query)
     .catch(function(err) {
         self.log('error/cassandra/table_creation', err);
         throw err;
     })
-    .then(function(currentSchemaInfo) {
+    .then(function(req) {
+        var currentSchemaInfo = req.schema;
         // Validate and normalize the schema
-        var schema = dbu.validateAndNormalizeSchema(req);
+        var newSchema = dbu.validateAndNormalizeSchema(req.query);
 
-        var schemaInfo = dbu.makeSchemaInfo(schema);
+        var newSchemaInfo = dbu.makeSchemaInfo(newSchema);
 
         if (currentSchemaInfo) {
             // Table already exists
             // Use JSON.stringify to avoid object equality on functions
-            if (JSON.stringify(currentSchemaInfo) === JSON.stringify(schemaInfo)) {
+            if (JSON.stringify(currentSchemaInfo) === JSON.stringify(newSchemaInfo)) {
                 // all good & nothing to do.
                 return {
                     status: 201
@@ -639,8 +624,8 @@ DB.prototype.createTable = function (reverseDomain, req) {
                     body: {
                         type: 'bad_request',
                         title: 'The table already exists, and its schema cannot be upgraded to the requested schema.',
-                        keyspace: keyspace,
-                        schema: schema
+                        keyspace: req.keyspace,
+                        schema: newSchema
                     }
                 });
             }
@@ -654,8 +639,8 @@ DB.prototype.createTable = function (reverseDomain, req) {
         var localDc = self.conf.localDc;
         var replicationOptions = "{ 'class': 'NetworkTopologyStrategy', '" + localDc + "': 3 }";
 
-        if (req.options) {
-            if (req.options.durability === 'low') {
+        if (req.query.options) {
+            if (req.query.options.durability === 'low') {
                 replicationOptions = "{ 'class': 'NetworkTopologyStrategy', '" + localDc + "': 1 }";
             }
         }
@@ -679,22 +664,28 @@ DB.prototype.createTable = function (reverseDomain, req) {
         var retries = 100; // We try really hard.
         var delay = 100; // Start with a 1ms delay
         function doCreateTables() {
-            return self._createKeyspace(keyspace, consistency, replicationOptions)
+            return self._createKeyspace(req, replicationOptions)
             .then(function() {
-                return self._createTable(keyspace, schemaInfo, 'data', consistency)
-                .then(function() {
-                    return self._createTable(keyspace, self.infoSchemaInfo, 'meta', consistency);
-                });
+                return self._createTable(req, newSchemaInfo, 'data');
+            })
+            // TODO: create indexes here rather than implicitly in
+            // _createTable?
+            .then(function() {
+                return self._createTable(req, self.infoSchemaInfo, 'meta');
             })
             .then(function() {
                 // Only store the schema after everything else was created
-                self.schemaCache[keyspace] = schemaInfo;
-                return self._put(keyspace, {
-                    attributes: {
-                        key: 'schema',
-                        value: schema
+                var putReq = req.extend({
+                    columnfamily: 'meta',
+                    schema: self.infoSchemaInfo,
+                    query: {
+                        attributes: {
+                            key: 'schema',
+                            value: newSchema
+                        }
                     }
-                }, consistency, 'meta')
+                });
+                return self._put(putReq)
                 .then(function() {
                     return {
                         status: 201
@@ -720,11 +711,11 @@ DB.prototype.createTable = function (reverseDomain, req) {
     });
 };
 
-DB.prototype._createTable = function (keyspace, schema, tableName, consistency) {
+DB.prototype._createTable = function (req, schema, columnfamily) {
     var self = this;
 
     if (!schema.attributes) {
-        throw new Error('No attribute definitions for table ' + tableName);
+        throw new Error('No attribute definitions for table ' + columnfamily);
     }
 
     var tasks = P.resolve();
@@ -733,7 +724,7 @@ DB.prototype._createTable = function (keyspace, schema, tableName, consistency) 
         Object.keys(schema.secondaryIndexes).forEach(function(idx) {
             var indexSchema = schema.secondaryIndexes[idx];
             tasks = tasks.then(function() {
-                return self._createTable(keyspace, indexSchema, 'idx_' + idx +"_ever");
+                return self._createTable(req, indexSchema, 'idx_' + idx +"_ever");
             });
         });
     }
@@ -747,7 +738,7 @@ DB.prototype._createTable = function (keyspace, schema, tableName, consistency) 
 
     // Finally, create the main data table
     var cql = 'create table if not exists '
-        + cassID(keyspace) + '.' + cassID(tableName) + ' (';
+        + cassID(req.keyspace) + '.' + cassID(columnfamily) + ' (';
     for (var attr in schema.attributes) {
         var type = schema.attributes[attr];
         cql += cassID(attr) + ' ' + dbu.schemaTypeToCQLType(type);
@@ -790,30 +781,29 @@ DB.prototype._createTable = function (keyspace, schema, tableName, consistency) 
     // matches / can be upgraded!
     // See https://phabricator.wikimedia.org/T75808.
     this.log('warn/table/cassandra/createTable', {
-        message: 'Creating table ' + tableName + ' in keyspace ' + keyspace,
-        table: tableName,
-        keyspace : keyspace
+        message: 'Creating CF ' + columnfamily + ' in keyspace ' + req.keyspace,
+        columnfamily: columnfamily,
+        keyspace : req.keyspace
     });
 
     // Execute the table creation query
     return tasks.then(function() {
-        return self.client.execute_p(cql, [], {consistency: consistency});
+        return self.client.execute_p(cql, [], {consistency: req.consistency});
     });
 };
 
-DB.prototype._createKeyspace = function (keyspace, consistency, options) {
-    var cql = 'create keyspace if not exists ' + cassID(keyspace)
+DB.prototype._createKeyspace = function (req, options) {
+    var cql = 'create keyspace if not exists ' + cassID(req.keyspace)
         + ' WITH REPLICATION = ' + options;
     return this.client.execute_p(cql, [],
-            {consistency: consistency || this.defaultConsistency});
+            {consistency: req.consistency || this.defaultConsistency});
 };
 
 
-DB.prototype.dropTable = function (reverseDomain, table) {
-    var keyspace = dbu.keyspaceName(reverseDomain, table);
+DB.prototype.dropTable = function (domain, table) {
+    var keyspace = dbu.keyspaceName(domain, table);
     return this.client.execute_p('drop keyspace ' + cassID(keyspace), [],
-            {consistency: this.defaultConsistency})
-    .delay(this.schemaSettleTime);
+            {consistency: this.defaultConsistency});
 };
 
 

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -50,7 +50,7 @@ dbu.cassID = function cassID (name) {
     }
 };
 
-dbu.idxTable = function idxTable (name, bucket) {
+dbu.idxColumnFamily = function idxColumnFamily (name, bucket) {
     var idx = 'idx_' + name;
     if (bucket) {
         return idx + '_' + bucket;
@@ -116,15 +116,16 @@ dbu.makeValidKey = function makeValidKey (key, length) {
  * if not possible. Also respect Cassandra's limit of 48 or fewer alphanum
  * chars & first char being an alpha char.
  *
- * @param {string} reverseDomain, a domain in reverse dot notation
- * @param {string} key, the bucket name to derive the key of
+ * @param {string} domain in dot notation
+ * @param {string} table, the logical table name
  * @return {string} Valid Cassandra keyspace key
  */
-dbu.keyspaceName = function keyspaceName (reverseDomain, key) {
-    var prefix = dbu.makeValidKey(reverseDomain, Math.max(26, 48 - key.length - 3));
+dbu.keyspaceName = function keyspaceName (domain, table) {
+    var reverseDomain = domain.toLowerCase().split('.').reverse().join('.');
+    var prefix = dbu.makeValidKey(reverseDomain, Math.max(26, 48 - table.length - 3));
     return prefix
         // 6 chars _hash_ to prevent conflicts between domains & table names
-        + '_T_' + dbu.makeValidKey(key, 48 - prefix.length - 3);
+        + '_T_' + dbu.makeValidKey(table, 48 - prefix.length - 3);
 };
 
 
@@ -439,6 +440,17 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
         }
     }
 
+    // Prefix a _domain attribute to each hash key, so that we can share CFs
+    // between groups of domains
+    psi.attributes._domain = 'string';
+    psi.index.unshift({ attribute: '_domain', type: 'hash' });
+    if (psi.secondaryIndexes) {
+        Object.keys(psi.secondaryIndexes).forEach(function(idxName) {
+            var idx = psi.secondaryIndexes[idxName];
+            idx.unshift({ attribute: '_domain', type: 'hash' });
+        });
+    }
+
     // Add a non-index _del flag to track deletions
     // This is normally null, but will be set on an otherwise empty row to
     // mark the row as deleted.
@@ -491,26 +503,44 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
  * @returns {Row} the row with converted attribute values
  */
 dbu.convertRow = function convertRow (row, schema) {
+    var newRow = {};
     Object.keys(row).forEach(function(att) {
-        if (row[att] !== null && schema.conversions[att] && schema.conversions[att].read) {
-            row[att] = schema.conversions[att].read(row[att]);
+        // Skip over internal attributes
+        if (!/^_/.test(att)) {
+            if (row[att] !== null && schema.conversions[att] && schema.conversions[att].read) {
+                newRow[att] = schema.conversions[att].read(row[att]);
+            } else {
+                newRow[att] = row[att];
+            }
         }
     });
-    return row;
+    return newRow;
 };
 
+/**
+ * Converts an array of result rows from Cassandra to JS values
+ *
+ * @param {array} rows the result rows to convert; not modified
+ * @param {object} schema the schema info to use for conversion
+ * @returns {array} a converted array of result rows
+ */
 dbu.convertRows = function convertRows (rows, schema) {
-    rows.forEach(function(row) {
-        dbu.convertRow(row, schema);
+    return rows.map(function(row) {
+        return dbu.convertRow(row, schema);
     });
-    return rows;
 };
 
 /*
  * # Section 3: CQL query generation
  */
 
-dbu.buildCondition = function buildCondition (pred, schema) {
+/**
+ * CQL building for conditional requests in general.
+ * @param {object} predicates, the 'attributes' object in queries.
+ * @param {object} schema, the schema info for the logical table.
+ * @return {object} queryInfo object with cql and params attributes
+ */
+dbu.buildCondition = function buildCondition (predicates, schema) {
     function convert(key, val) {
         var convObj = schema.conversions[key];
         if (convObj && convObj.write) {
@@ -522,9 +552,9 @@ dbu.buildCondition = function buildCondition (pred, schema) {
 
     var params = [];
     var conjunctions = [];
-    Object.keys(pred).forEach(function(predKey) {
+    Object.keys(predicates).forEach(function(predKey) {
         var cql = '';
-        var predObj = pred[predKey];
+        var predObj = predicates[predKey];
         cql += dbu.cassID(predKey);
         if (predObj === undefined) {
             throw new Error('Query error: attribute ' + JSON.stringify(predKey)
@@ -574,27 +604,36 @@ dbu.buildCondition = function buildCondition (pred, schema) {
                 default: throw new Error ('Operator ' + predOp + ' not supported!');
                 }
             } else {
-                throw new Error ('Invalid predicate ' + JSON.stringify(pred));
+                throw new Error ('Invalid predicate ' + JSON.stringify(predicates));
             }
         }
         conjunctions.push(cql);
     });
     return {
-        query: conjunctions.join(' AND '),
+        cql: conjunctions.join(' AND '),
         params: params,
     };
 };
 
-dbu.buildPutQuery = function(req, keyspace, table, schema) {
+
+/**
+ * CQL building for PUT queries
+ * @param {InternalRequest} req
+ * @return {object} queryInfo object with cql and params attributes
+ */
+dbu.buildPutQuery = function(req) {
 
     //table = schema.table;
 
-    if (!schema) {
+    if (!req.schema) {
         throw new Error('Table not found!');
     }
+    var schema = req.schema;
+    var query = req.query;
 
     // Convert the attributes
-    var attributes = req.attributes;
+    var attributes = query.attributes || {};
+    attributes._domain = req.domain;
     var conversions = schema.conversions || {};
 
     // XXX: should we require non-null secondary index entries too?
@@ -602,7 +641,7 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
     schema.iKeys.forEach(function(key) {
         if (attributes[key] === undefined) {
             throw new Error("Index attribute " + JSON.stringify(key) + " missing in "
-                    + JSON.stringify(req) + "; schema: " + JSON.stringify(schema, null, 2));
+                    + JSON.stringify(query) + "; schema: " + JSON.stringify(schema, null, 2));
         } else {
             indexKVMap[key] = attributes[key];
         }
@@ -635,9 +674,9 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
     var usingParams = [];
     var usingTypeHints = [];
     var usingParamsKeys = [];
-    if (req.timestamp && !req.if) {
+    if (query.timestamp && !query.if) {
         using = ' USING TIMESTAMP ? ';
-        usingParams.push(cass.types.Long.fromNumber(Math.round(req.timestamp * 1000)));
+        usingParams.push(cass.types.Long.fromNumber(Math.round(query.timestamp * 1000)));
         usingParamsKeys.push(null);
     }
 
@@ -650,19 +689,19 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
 
     var cql = '', condResult;
 
-    if (req.if && req.if.constructor === String) {
-        req.if = req.if.trim().split(/\s+/).join(' ').toLowerCase();
+    if (query.if && query.if.constructor === String) {
+        query.if = query.if.trim().split(/\s+/).join(' ').toLowerCase();
     }
 
     var condRes = dbu.buildCondition(indexKVMap, schema);
 
     var cond = '';
-    if (!haveNonIndexNonNullValue || req.if === 'not exists') {
-        if (req.if === 'not exists') {
+    if (!haveNonIndexNonNullValue || query.if === 'not exists') {
+        if (query.if === 'not exists') {
             cond = ' if not exists ';
         }
         var proj = schema.iKeys.concat(nonIndexKeys).map(dbu.cassID).join(',');
-        cql = 'insert into ' + dbu.cassID(keyspace) + '.' + dbu.cassID(table)
+        cql = 'insert into ' + dbu.cassID(req.keyspace) + '.' + dbu.cassID(req.columnfamily)
                 + ' (' + proj + ') values (';
         cql += placeholders.join(',') + ')' + cond + using;
         params = condRes.params.concat(params, usingParams);
@@ -670,18 +709,18 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
         var condParams = [];
         var condTypeHints = [];
         var condParamKeys = [];
-        if (req.if) {
+        if (query.if) {
             cond = ' if ';
-            condResult = dbu.buildCondition(req.if, schema);
-            cond += condResult.query;
+            condResult = dbu.buildCondition(query.if, schema);
+            cond += condResult.cql;
             condParams = condResult.params;
             condParamKeys = condResult.keys;
         }
 
         var updateProj = nonIndexKeys.map(dbu.cassID).join(' = ?,') + ' = ? ';
-        cql += 'update ' + dbu.cassID(keyspace) + '.' + dbu.cassID(table)
+        cql += 'update ' + dbu.cassID(req.keyspace) + '.' + dbu.cassID(req.columnfamily)
                + using + ' set ' + updateProj + ' where ';
-        cql += condRes.query + cond;
+        cql += condRes.cql + cond;
         params = usingParams.concat(params, condRes.params, condParams);
 
     } else {
@@ -689,30 +728,41 @@ dbu.buildPutQuery = function(req, keyspace, table, schema) {
     }
 
     return {
-        query: cql,
+        cql: cql,
         params: params,
     };
 };
 
-dbu.buildGetQuery = function(keyspace, req, consistency, table, schema) {
+
+/**
+ * CQL building for GET queries
+ * @param {InternalRequest} req
+ * @return {object} queryInfo object with cql and params attributes
+ */
+dbu.buildGetQuery = function(req) {
     var proj = '*';
 
-    if (req.index) {
-        if (!schema.secondaryIndexes[req.index]) {
+    var query = req.query;
+    if (!query) {
+        throw new Error('Query missing!');
+    }
+    var schema = req.schema;
+    if (query.index) {
+        if (!schema.secondaryIndexes[query.index]) {
             // console.dir(cachedSchema);
-            throw new Error("Index not found: " + req.index);
+            throw new Error("Index not found: " + query.index);
         }
-        schema = schema.secondaryIndexes[req.index];
-        table = dbu.idxTable(req.index);
+        schema = schema.secondaryIndexes[query.index];
+        req.columnfamily = dbu.idxColumnFamily(query.index);
     }
 
-    if (req.proj) {
-        if (Array.isArray(req.proj)) {
-            proj = req.proj.map(dbu.cassID).join(',');
-        } else if (req.proj.constructor === String) {
-            proj = dbu.cassID(req.proj);
+    if (query.proj) {
+        if (Array.isArray(query.proj)) {
+            proj = query.proj.map(dbu.cassID).join(',');
+        } else if (query.proj.constructor === String) {
+            proj = dbu.cassID(query.proj);
         }
-    } else if (req.order) {
+    } else if (query.order) {
         // Work around 'order by' bug in cassandra when using *
         // Trying to change the natural sort order only works with a
         // projection in 2.0.9
@@ -721,42 +771,41 @@ dbu.buildGetQuery = function(keyspace, req, consistency, table, schema) {
         }
     }
 
-    if (req.limit && req.limit.constructor !== Number) {
-        req.limit = undefined;
+    if (query.limit && query.limit.constructor !== Number) {
+        query.limit = undefined;
     }
 
 
-    if (req.distinct) {
+    if (query.distinct) {
         proj = 'distinct ' + proj;
     }
 
     var cql = 'select ' + proj + ' from '
-        + dbu.cassID(keyspace) + '.' + dbu.cassID(table);
+        + dbu.cassID(req.keyspace) + '.' + dbu.cassID(req.columnfamily);
 
     // Build up the condition
     var params = [];
-    var attributes = req.attributes;
-    if (attributes) {
-        Object.keys(attributes).forEach(function(key) {
-            // req should not have non key attributes
-            if (!schema.iKeyMap[key]) {
-                throw new Error("All request attributes need to be key attributes. Bad attribute: "
-                        + key);
-            }
-        });
-        cql += ' where ';
-        var condResult = dbu.buildCondition(attributes, schema);
-        cql += condResult.query;
-        params = condResult.params;
-    }
+    var attributes = query.attributes || {};
+    attributes._domain = req.domain;
+    Object.keys(attributes).forEach(function(key) {
+        // query should not have non key attributes
+        if (!schema.iKeyMap[key]) {
+            throw new Error("All request attributes need to be key attributes. Bad attribute: "
+                    + key);
+        }
+    });
+    cql += ' where ';
+    var condResult = dbu.buildCondition(attributes, schema);
+    cql += condResult.cql;
+    params = condResult.params;
 
-    if (req.order) {
+    if (query.order) {
         var reversed;
         // Establish whether we need to read in forward or reverse order,
         // which is what Cassandra supports. Also validate the order for
         // consistency.
-        for (var att in req.order) {
-            var dir = req.order[att];
+        for (var att in query.order) {
+            var dir = query.order[att];
             if (dir !== 'asc' && dir !== 'desc') {
                 throw new Error("Invalid sort order " + dir + " on key " + att);
             }
@@ -792,11 +841,11 @@ dbu.buildGetQuery = function(keyspace, req, consistency, table, schema) {
         }
     }
 
-    if (req.limit) {
-        cql += ' limit ' + req.limit;
+    if (query.limit) {
+        cql += ' limit ' + query.limit;
     }
 
-    return {query: cql, params: params};
+    return {cql: cql, params: params};
 };
 
 

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -5,11 +5,10 @@ var cass = require('cassandra-driver');
 var TimeUuid = cass.types.TimeUuid;
 var dbu = require('./dbutils');
 
-function IndexRebuilder (db, keyspace, schema, secondaryKeys, timestamp) {
+function IndexRebuilder (db, req, secondaryKeys, timestamp) {
     this.db = db;
-    this.keyspace = keyspace;
-    this.schema = schema;
-    this.primaryKeys = schema.iKeys;
+    this.req = req;
+    this.primaryKeys = this.req.schema.iKeys;
     this.secondaryKeys = secondaryKeys;
 
     this.prevRow = null;
@@ -76,7 +75,7 @@ IndexRebuilder.prototype.handleRow = function (n, row) {
     var idxSet = {};
     // Figure out which indexes need to be updated
     for (var diffAtt in diff) {
-        var idxes = this.schema.attributeIndexes[diffAtt];
+        var idxes = this.req.schema.attributeIndexes[diffAtt];
         if (idxes) {
             idxes.forEach(function(idx) {
                 idxSet[idx] = true;
@@ -86,23 +85,26 @@ IndexRebuilder.prototype.handleRow = function (n, row) {
     var queries = [];
     for (var idx in idxSet) {
         var reqAttributes = {};
-        var secondarySchema = this.schema.secondaryIndexes[idx];
+        var secondarySchema = this.req.schema.secondaryIndexes[idx];
         for (var att in secondarySchema.attributes) {
             reqAttributes[att] = row[att];
         }
 
         // Write everything but _del with the corresponding data row's
         // timestamp
-        var writeTime = dbu.tidNanoTime(row[this.schema.tid]);
-        var idxReq = {
-            attributes: reqAttributes,
-            // Add the timestamp clause
-            timestamp: writeTime
-        };
-        var queryObj = dbu.buildPutQuery(idxReq, this.keyspace,
-                dbu.idxTable(idx), secondarySchema);
+        var writeTime = dbu.tidNanoTime(row[this.req.schema.tid]);
+        var idxReq = self.req.extend({
+            query: {
+                attributes: reqAttributes,
+                // Add the timestamp clause
+                timestamp: writeTime
+            },
+            columnfamily: dbu.idxColumnFamily(idx),
+            schema: secondarySchema
+        });
+        var queryObj = dbu.buildPutQuery(idxReq);
         queries.push(
-            this.db.client.execute_p(queryObj.query, queryObj.params,
+            self.db.client.execute_p(queryObj.cql, queryObj.params,
                 { consistency: cass.types.consistencies.one, prepare: true })
             .catch(function(e) {
                 self.db.log('error/table/cassandra/secondaryIndexUpdate', e);
@@ -115,17 +117,16 @@ IndexRebuilder.prototype.handleRow = function (n, row) {
             secondarySchema.iKeys.forEach(function(att) {
                 delReqAttributes[att] = row[att];
             });
-            delReqAttributes._del = this.prevRow[this.schema.tid];
-            var delReq = {
-                attributes: delReqAttributes,
-                timestamp: this.delWriteTimestamp
-            };
-            //console.log(this.schema.table, delReqAttributes.uri,
-            //        delReqAttributes._del, delReq.timestamp);
-            var delQueryObj = dbu.buildPutQuery(delReq, this.keyspace,
-                    dbu.idxTable(idx), secondarySchema);
+            delReqAttributes._del = self.prevRow[self.req.schema.tid];
+            var delReq = idxReq.extend({
+                query: {
+                    attributes: delReqAttributes,
+                    timestamp: self.delWriteTimestamp
+                }
+            });
+            var delQueryObj = dbu.buildPutQuery(delReq);
             queries.push(
-                this.db.client.execute_p(delQueryObj.query, delQueryObj.params,
+                this.db.client.execute_p(delQueryObj.cql, delQueryObj.params,
                     { consistency: cass.types.consistencies.one, prepare: true })
                 .catch(function(e) {
                     self.db.log('error/table/cassandra/secondaryIndexUpdate', e);
@@ -136,8 +137,7 @@ IndexRebuilder.prototype.handleRow = function (n, row) {
     }
     this.prevRow = row;
 
-    return P.all(queries)
-    .then(function() { return; });
+    return P.all(queries);
 };
 
 module.exports = {

--- a/test/index.js
+++ b/test/index.js
@@ -610,7 +610,6 @@ describe('DB backend', function() {
                 deepEqual(response.items, [{ key: 'testing',
                     tid: '28730300-0095-11e3-9234-0123456789ab',
                     latestTid: null,
-                    _del: null,
                     body: null,
                     'content-length': null,
                     'content-location': null,
@@ -637,7 +636,6 @@ describe('DB backend', function() {
                 deepEqual(response.body.items, [ { key: 'testing',
                     tid: '28730300-0095-11e3-9234-0123456789ab',
                     latestTid: null,
-                    _del: null,
                     body: null,
                     'content-length': null,
                     'content-location': null,
@@ -647,47 +645,46 @@ describe('DB backend', function() {
                 } ]);
             });
         });
-        it('simple get with paging', function() {
-            return router.request({
-                uri:'/restbase.cassandra.test.local/sys/table/simple-table/',
-                method: 'get',
-                body: {
-                    table: "simple-table",
-                    pageSize: 1,
-                    attributes: {
-                        key: 'testing',
-                    }
-                }
-            })
-            .then(function(response) {
-                deepEqual(response.body.items.length, 1);
-                return router.request({
-                    uri:'/restbase.cassandra.test.local/sys/table/simple-table/',
-                    method: 'get',
-                    body: {
-                        table: "simple-table",
-                        pageSize: 1,
-                        next: response.body.next,
-                        attributes: {
-                            key: 'testing',
-                        }
-                    }
-                });
-            })
-            .then(function(response) {
-                deepEqual(response.body.items[0], { key: 'testing',
-                    tid: '28730300-0095-11e3-9234-0123456789ab',
-                    latestTid: null,
-                    _del: null,
-                    body: null,
-                    'content-length': null,
-                    'content-location': null,
-                    'content-sha256': null,
-                    'content-type': null,
-                    restrictions: null
-                });
-            });
-        });
+        //it('simple get with paging', function() {
+        //    return router.request({
+        //        uri:'/restbase.cassandra.test.local/sys/table/simple-table/',
+        //        method: 'get',
+        //        body: {
+        //            table: "simple-table",
+        //            pageSize: 1,
+        //            attributes: {
+        //                key: 'testing',
+        //            }
+        //        }
+        //    })
+        //    .then(function(response) {
+        //        deepEqual(response.body.items.length, 1);
+        //        return router.request({
+        //            uri:'/restbase.cassandra.test.local/sys/table/simple-table/',
+        //            method: 'get',
+        //            body: {
+        //                table: "simple-table",
+        //                pageSize: 1,
+        //                next: response.body.next,
+        //                attributes: {
+        //                    key: 'testing',
+        //                }
+        //            }
+        //        });
+        //    })
+        //    .then(function(response) {
+        //        deepEqual(response.body.items[0], { key: 'testing',
+        //            tid: '28730300-0095-11e3-9234-0123456789ab',
+        //            latestTid: null,
+        //            body: null,
+        //            'content-length': null,
+        //            'content-location': null,
+        //            'content-sha256': null,
+        //            'content-type': null,
+        //            restrictions: null
+        //        });
+        //    });
+        //});
         it("index query for values that doesn't match any more", function() {
             return router.request({
                 uri: "/restbase.cassandra.test.local/sys/table/simpleSecondaryIndexTable/",
@@ -764,7 +761,7 @@ describe('DB backend', function() {
     //TODO: implement this using http handler when alternate rest-url for delete item are supported
     describe('delete', function() {
         it('simple delete query', function() {
-            return DB.delete('local.test.cassandra.restbase', {
+            return DB.delete('restbase.cassandra.test.local', {
                 table: "simple-table",
                 attributes: {
                     tid: dbu.testTidFromDate(new Date('2013-08-09 18:43:58-0700')),
@@ -975,6 +972,9 @@ describe('DB backend', function() {
                 method: 'get',
                 body: {
                     table: "typeTable",
+                    attributes: {
+                        string: 'string'
+                    },
                     proj: ['string','blob','set','int','varint', 'decimal',
                             'float', 'double','boolean','timeuuid','uuid',
                             'timestamp','json']
@@ -1024,13 +1024,16 @@ describe('DB backend', function() {
                 method: 'get',
                 body: {
                     table: "typeTable",
+                    attributes: {
+                        int: '1'
+                    },
                     index: 'test',
-                    proj: ['int']
+                    proj: ['int', 'boolean']
                 }
             })
             .then(function(response){
                 response.body.items[0].int = 1;
-                response.body.items[1].int = -1;
+                response.body.items[0].boolean = true;
             });
         });
         it("get sets", function() {
@@ -1039,6 +1042,9 @@ describe('DB backend', function() {
                 method: 'get',
                 body: {
                     table: "typeSetsTable",
+                    attributes: {
+                        string: 'string'
+                    },
                     proj: ['string','blob','set','int','varint', 'decimal',
                             'double','boolean','timeuuid','uuid', 'float',
                             'timestamp','json']


### PR DESCRIPTION
This patch prefixes a private `_domain` key element to each hash key, which in
turn lets us share a single CF for several domains. With this patch, all but
two listing tests (for titles and revisions) in restbase are passing. This is
the expected consequence of our strategy of using compound primary keys. The
ability to list hash keys can be restored later using secondary indexes.

Also:

- Introduced an `InternalRequest` class and a `_makeInternalRequest` method to
  set up and systematically handle request-related state. This cuts down the
  number of positional parameters drastically and replaces common boilerplate
  in `get()`, `put()`.

- Removed the now-dead `getSchema` and `_getSchema` methods. This
  functionality is now provided by `_makeInternalRequest`.

- Prepared for a removal of the `table` property in queries. Conceptually, the
  logical table is the resource to execute a query on, so should be part of
  the URI rather than the request body.

- Adjusted some tests to reflect the current limitation of no listings on hash
  keys. We could lift this limitation later, as described above.

- Added systematic private attribute stripping (all attributes starting with
  on an underscore) on the way out. This removes the previously-leaking `_del`
  attribute from the output.

- Commented out paging support and the single corresponding test. This code is
  not actually secure (clients can pass in arbitrary paging state), and needs
  an overhaul before we can re-enable paging. See
  https://phabricator.wikimedia.org/T85640.

- Commented out _getSecondaryIndex. This is not currently used, and needs an
  overhaul / rethink.

Next steps:

- Map groups of domains to internal storage domains in `dbu.keyspaceName()`.
  This will actually enable sharing.

Bug: https://phabricator.wikimedia.org/T91188