### PR TITLE
Performance: Optimize convertRows

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -496,28 +496,6 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
 
 
 /**
- * Converts a result row from Cassandra to JS values
- *
- * @param {Row} row the result row to convert; modified in place
- * @param {Schema} schema the schema to use for conversion
- * @returns {Row} the row with converted attribute values
- */
-dbu.convertRow = function convertRow (row, schema) {
-    var newRow = {};
-    Object.keys(row).forEach(function(att) {
-        // Skip over internal attributes
-        if (!/^_/.test(att)) {
-            if (row[att] !== null && schema.conversions[att] && schema.conversions[att].read) {
-                newRow[att] = schema.conversions[att].read(row[att]);
-            } else {
-                newRow[att] = row[att];
-            }
-        }
-    });
-    return newRow;
-};
-
-/**
  * Converts an array of result rows from Cassandra to JS values
  *
  * @param {array} rows the result rows to convert; not modified
@@ -525,9 +503,25 @@ dbu.convertRow = function convertRow (row, schema) {
  * @returns {array} a converted array of result rows
  */
 dbu.convertRows = function convertRows (rows, schema) {
-    return rows.map(function(row) {
-        return dbu.convertRow(row, schema);
-    });
+    var conversions = schema.conversions;
+    var newRows = new Array(rows.length);
+    for (var i = 0; i < rows.length; i++) {
+        var row = rows[i];
+        var newRow = {};
+        Object.keys(row).forEach(function(att) {
+            // Skip over internal attributes
+            if (!/^_/.test(att)) {
+                if (row[att] !== null && conversions[att]
+                        && conversions[att].read) {
+                    newRow[att] = schema.conversions[att].read(row[att]);
+                } else {
+                    newRow[att] = row[att];
+                }
+            }
+        });
+        newRows[i] = newRow;
+    }
+    return newRows;
 };
 
 /*


### PR DESCRIPTION
This is a very hot function as it's applied to all result rows. Also removed
the per-row convertRow method, as it's not actually needed.

Notes:

- using `delete` to remove private attributes is slower than reconstructing
  the entire row
- pre-allocating the Array & then iterating over it is faster than `map`
- there is some potential to be even faster with in-place updates by setting
  private attributes to `undefined`, but that's somewhat ugly as it doesn't
  actually remove those keys from `Object.keys()`.