### PR TITLE
Don't multiplex meta tables across domains

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,3 +1,4 @@
 node_modules
 test
 scripts
+coverage

--- a/lib/db.js
+++ b/lib/db.js
@@ -198,7 +198,7 @@ DB.prototype.infoSchema = dbu.validateAndNormalizeSchema({
     secondaryIndexes: {}
 });
 
-DB.prototype.infoSchemaInfo = dbu.makeSchemaInfo(DB.prototype.infoSchema);
+DB.prototype.infoSchemaInfo = dbu.makeSchemaInfo(DB.prototype.infoSchema, true);
 
 DB.prototype.get = function (domain, query) {
     var self = this;

--- a/lib/db.js
+++ b/lib/db.js
@@ -22,6 +22,7 @@ function DB (client, options) {
 
     // cache keyspace -> schema
     this.schemaCache = {};
+    this.keyspaceSchemaCache = {};
     this.keyspaceNameCache = {};
 
     /* Process the array of storage groups declared in the config */
@@ -52,6 +53,10 @@ DB.prototype._makeInternalRequest = function (domain, table, query, consistency)
         columnfamily: 'data',
         schema: this.schemaCache[cacheKey]
     });
+    if (!req.schema) {
+        // Share the schema across domains that map to the same keyspace
+        req.schema = this.keyspaceSchemaCache[req.keyspace];
+    }
     if (req.schema) {
         return P.resolve(req);
     } else {
@@ -74,6 +79,7 @@ DB.prototype._makeInternalRequest = function (domain, table, query, consistency)
                 var schema = JSON.parse(res.items[0].value);
                 self.keyspaceNameCache[cacheKey] = req.keyspace;
                 self.schemaCache[cacheKey] = req.schema = dbu.makeSchemaInfo(schema);
+                self.keyspaceSchemaCache[req.keyspace] = req.schema;
             }
             return req;
         }, function(err) {
@@ -697,7 +703,7 @@ DB.prototype.createTable = function (domain, query) {
         if (currentSchemaInfo) {
             // Table already exists
             // Use JSON.stringify to avoid object equality on functions
-            if (JSON.stringify(currentSchemaInfo) === JSON.stringify(newSchemaInfo)) {
+            if (currentSchemaInfo.hash === newSchemaInfo.hash) {
                 // all good & nothing to do.
                 return {
                     status: 201

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -393,7 +393,7 @@ dbu.conversions = {
 /*
  * Derive additional schema info from the public schema
  */
-dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
+dbu.makeSchemaInfo = function makeSchemaInfo(schema, isMetaCF) {
     // Private schema information
     // Start with a deep clone of the schema
     var psi = extend(true, {}, schema);
@@ -421,15 +421,17 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema) {
         }
     }
 
-    // Prefix a _domain attribute to each hash key, so that we can share CFs
-    // between groups of domains
-    psi.attributes._domain = 'string';
-    psi.index.unshift({ attribute: '_domain', type: 'hash' });
-    if (psi.secondaryIndexes) {
-        Object.keys(psi.secondaryIndexes).forEach(function(idxName) {
-            var idx = psi.secondaryIndexes[idxName];
-            idx.unshift({ attribute: '_domain', type: 'hash' });
-        });
+    if (!isMetaCF) {
+        // Prefix a _domain attribute to each hash key, so that we can share CFs
+        // between groups of domains
+        psi.attributes._domain = 'string';
+        psi.index.unshift({ attribute: '_domain', type: 'hash' });
+        if (psi.secondaryIndexes) {
+            Object.keys(psi.secondaryIndexes).forEach(function(idxName) {
+                var idx = psi.secondaryIndexes[idxName];
+                idx.unshift({ attribute: '_domain', type: 'hash' });
+            });
+        }
     }
 
     // Add a non-index _del flag to track deletions
@@ -614,7 +616,9 @@ dbu.buildPutQuery = function(req) {
 
     // Convert the attributes
     var attributes = query.attributes || {};
-    attributes._domain = req.domain;
+    if (req.columnfamily !== 'meta') {
+        attributes._domain = req.domain;
+    }
     var conversions = schema.conversions || {};
 
     // XXX: should we require non-null secondary index entries too?
@@ -767,7 +771,9 @@ dbu.buildGetQuery = function(req) {
     // Build up the condition
     var params = [];
     var attributes = query.attributes || {};
-    attributes._domain = req.domain;
+    if (req.columnfamily !== 'meta') {
+        attributes._domain = req.domain;
+    }
     Object.keys(attributes).forEach(function(key) {
         // query should not have non key attributes
         if (!schema.iKeyMap[key]) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -474,6 +474,11 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema, isMetaCF) {
     }
     psi.attributeIndexes = attributeIndexes;
 
+
+    // define a 'hash' string representation for the schema for quick schema
+    // comparisons.
+    psi.hash = JSON.stringify(psi);
+
     return psi;
 };
 


### PR DESCRIPTION
Meta tables track the table schema and potentially other table metadata, which
can't differ between domains. Thus, don't multiplex on domain for meta tables.

This avoids per-domain table creation & schema update attempts.