### PR TITLE
Clean up the cassandra driver configuration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,8 @@
 
 var P = require('bluebird');
 var cass = require('cassandra-driver');
+var loadBalancing = cass.policies.loadBalancing;
+var reconnection = cass.policies.reconnection;
 var DB = require('./db');
 
 P.promisifyAll(cass, { suffix: '_p' });
@@ -13,14 +15,17 @@ function makeClient (options) {
     clientOpts.contactPoints = conf.hosts;
     // Default to 'datacenter1'
     if (!conf.localDc) { conf.localDc = 'datacenter1'; }
-    // See http://www.datastax.com/drivers/nodejs/1.0/module-policies_loadBalancing-DCAwareRoundRobinPolicy.html
-    clientOpts.loadBalancing = new cass.policies
-        .loadBalancing.DCAwareRoundRobinPolicy(conf.localDc);
-    // Also see
-    // http://www.datastax.com/documentation/developer/nodejs-driver/1.0/common/drivers/reference/clientOptions.html
-    clientOpts.reconnection = new cass.policies
+    // See http://www.datastax.com/drivers/nodejs/2.0/module-policies_loadBalancing-DCAwareRoundRobinPolicy.html
+    clientOpts.policies = {
+        loadBalancing: new loadBalancing.TokenAwarePolicy(
+            new loadBalancing.DCAwareRoundRobinPolicy(conf.localDc)
+        ),
+        // Also see
+        // http://www.datastax.com/documentation/developer/nodejs-driver/2.0/common/drivers/reference/clientOptions.html
         // Retry immediately, then delay by 100ms, back off up to 2000ms
-        .reconnection.ExponentialReconnectionPolicy(100, 2000, true);
+        reconnection: new reconnection.ExponentialReconnectionPolicy(100, 2000, true)
+    };
+
     if (conf.username && conf.password) {
         clientOpts.authProvider = new cass.auth.PlainTextAuthProvider(
                 conf.username, conf.password);
@@ -46,7 +51,10 @@ function makeClient (options) {
         });
     });
 
-    return P.resolve(new DB(client, options));
+    return client.connect_p()
+    .then(function() {
+        return new DB(client, options);
+    });
 }
 
 module.exports = makeClient;


### PR DESCRIPTION
- Our previous policies were actually not used at all. They are supposed to be
  set in a 'policies' object rather than directly on the client options. This
  explains why reconnections were still so slow.

- Call connect() on the client before building the DB object. This provides an
  early failure detection.