### PR TITLE
Stop creating native Cassandra indexes on _domain

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -877,23 +877,9 @@ DB.prototype._createTable = function (req, schema, columnfamily) {
     });
 
     // Execute the table creation query
-    var tableCreation = tasks.then(function() {
+    return tasks.then(function() {
         return self.client.execute_p(cql, [], {consistency: req.consistency});
     });
-
-    // Create a Cassandra-native secondary index on the _domain attribute, for
-    // all tables except meta.
-    if (columnfamily !== 'meta') {
-        return tableCreation.then(function() {
-            var createIdx = 'CREATE INDEX IF NOT EXISTS ON '
-                + cassID(req.keyspace) + '.' + cassID(columnfamily) + ' ("_domain")';
-            return self.client.execute_p(createIdx, [], {consistency: req.consistency});
-        });
-    }
-    else {
-        return tableCreation;
-    }
-
 };
 
 DB.prototype._createKeyspace = function (req, options) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -700,10 +700,19 @@ DB.prototype.createTable = function (domain, query) {
 
         var newSchemaInfo = dbu.makeSchemaInfo(newSchema);
 
+
         if (currentSchemaInfo) {
             // Table already exists
             // Use JSON.stringify to avoid object equality on functions
             if (currentSchemaInfo.hash === newSchemaInfo.hash) {
+                if (!currentSchemaInfo._domainIndexDropped) {
+                    // Hacky flag to avoid dropping index on each request.
+                    // TODO: Properly keep track of internal schema versions!
+                    currentSchemaInfo._domainIndexDropped= true;
+                    // Asynchronously drop native secondary index on _domain column
+                    self._dropDomainIndex(req);
+                }
+
                 // all good & nothing to do.
                 return {
                     status: 201
@@ -879,6 +888,21 @@ DB.prototype._createTable = function (req, schema, columnfamily) {
     // Execute the table creation query
     return tasks.then(function() {
         return self.client.execute_p(cql, [], {consistency: req.consistency});
+    });
+};
+
+// Drop the native secondary indexes we used to create on the "_domain" column.
+DB.prototype._dropDomainIndex = function(req) {
+    var self = this;
+    var cql = "select index_name from system.schema_columns where keyspace_name = ? "
+        + " and columnfamily_name = ? and column_name = '_domain';";
+    return self.client.execute_p(cql, [req.keyspace, req.columnfamily], {prepare: true})
+    .then(function(res) {
+        if (res.rows.length && res.rows[0].index_name) {
+            // drop the index
+            return self.client.execute_p('drop index if exists ' + cassID(req.keyspace)
+                    + '.' + cassID(res.rows[0].index_name));
+        }
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "dependencies": {
     "async": "0.x.x",
     "bluebird": "~2.3.10",


### PR DESCRIPTION
A bug in Cassandra 2.1 causes inserts in tables with native secondary indexes
on _domain to fail if the size of any column value exceeds a fairly low
threshold (16k IIRC). This is a problem especially on tables backing content
tables like those behind key_rev_value storage.

This patch stops creating those secondary indexes by default. This will break
the hacky revision and title listings in RESTBase, which we should disable or
replace with API requests.

Next steps in the backend:

- Automatically drop existing secondary indexes on `_domain`. Naming scheme is
  `<table_name>_<column_name>_idx_<counter>`, with the main difficulty being
  the counter value.