### PR TITLE
Remove native-secondary-index creation

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -877,22 +877,9 @@ DB.prototype._createTable = function (req, schema, columnfamily) {
     });
 
     // Execute the table creation query
-    var tableCreation = tasks.then(function() {
+    return tasks.then(function() {
         return self.client.execute_p(cql, [], {consistency: req.consistency});
     });
-
-    // Create a Cassandra-native secondary index on the _domain attribute, for
-    // all tables except meta.
-    if (columnfamily !== 'meta') {
-        return tableCreation.then(function() {
-            var createIdx = 'CREATE INDEX IF NOT EXISTS ON '
-                + cassID(req.keyspace) + '.' + cassID(columnfamily) + ' ("_domain")';
-            return self.client.execute_p(createIdx, [], {consistency: req.consistency});
-        });
-    }
-    else {
-        return tableCreation;
-    }
 
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "dependencies": {
     "async": "0.x.x",
     "bluebird": "~2.3.10",


### PR DESCRIPTION
Due to a bug in Cassandra 2.1, we cannot effectively use native secondary indices on domains.

This PR reverts #86 and represents an alternative to #89 .