### PR TITLE
implement revision retention policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ coverage/
 .coveralls.yml
 node_modules
 npm-debug.log
+.tern-project
+.tern-port
+*~

--- a/lib/db.js
+++ b/lib/db.js
@@ -6,6 +6,7 @@ var TimeUuid = cass.types.TimeUuid;
 var extend = require('extend');
 var dbu = require('./dbutils');
 var cassID = dbu.cassID;
+var revPolicy = require('./revisionPolicy');
 var secIndexes = require('./secondaryIndexes');
 
 
@@ -525,7 +526,7 @@ DB.prototype._put = function(req) {
     .then(function(result) {
         // Kick off asynchronous local index rebuild
         if (schema.secondaryIndexes) {
-            self._rebuildIndexes(req, 3)
+            self._backgroundUpdates(req, 3)
             .catch(function(err) {
                 self.log('error/cassandra/rebuildIndexes', err);
             });
@@ -539,134 +540,113 @@ DB.prototype._put = function(req) {
     });
 };
 
-
 /*
- * Index update algorithm
+ * Post-put background updates
  *
- * look at sibling revisions to update the index with values that no longer match
+ * look at sibling revisions to update the index with values that no longer
+ * match, and apply the schema-specified revision retention policy.
  *   - select sibling revisions
- *   - walk results in ascending order and diff each row vs. preceding row
- *      - if diff: for each index affected by that diff, update _deleted for old value
- *        using that revision's TIMESTAMP.
- * @param {object} InternalRequest; pass in an empty query to match / rebuild
+ *   - walk results in ascending order and:
+ *      - diff each row vs. preceding row
+ *         - if diff: for each index affected by that diff, update _del for old
+ *           value using that revision's TIMESTAMP.
+ *      - apply the revision retention policy.
+ * @param {object} InternalRequest; pass in an empty query to match / update
  *        all entries
- * @param {number} limit [optional] The maximum number of entries to include in
- *      the index update.
- * @param {array} (optional) indexes, an array of index names to update;
+ * @param {number} (optional) limit; The maximum number of entries to include
+ *        in the updates.
+ * @param  {array} (optional) indexes; an array of index names to update;
  *      Default: all indexes in the schema
  */
-DB.prototype._rebuildIndexes = function (req, limit, indexes) {
+DB.prototype._backgroundUpdates = function(req, limit, indexes) {
     var self = this;
     var schema = req.schema;
     var query = req.query;
-    if (!indexes) {
-        indexes = Object.keys(schema.secondaryIndexes);
-    }
-    if (indexes.length) {
-        // Don't need more than consistency one for background index updates
-        var consistency = cass.types.consistencies.one;
-        var tidKey = schema.tid;
+    indexes = indexes || Object.keys(schema.secondaryIndexes);
 
-        // Build a new request for the main data table
-        var dataQuery = {
-            table: query.table,
-            attributes: {},
-            proj: []
-        };
-
-        // Narrow down the update to the original request's primary key. If
-        // that's empty, the entire index (within the numerical limits) will be updated.
-        schema.iKeys.forEach(function(att) {
-            if (att !== tidKey) {
-                dataQuery.attributes[att] = query.attributes[att];
-                dataQuery.proj.push(att);
-            }
-        });
-
-        // Select indexed attributes for all indexes to rebuild
-        var secondaryKeySet = {};
-        indexes.forEach(function(idx) {
-            // console.log(idx, JSON.stringify(schema.secondaryIndexes));
-            Object.keys(schema.attributeIndexes).forEach(function(att) {
-                if (!schema.iKeyMap[att] && !secondaryKeySet[att]) {
-                    dataQuery.proj.push(att);
-                    secondaryKeySet[att] = true;
-                }
-            });
-        });
-        var secondaryKeys = Object.keys(secondaryKeySet);
-        // Include the data table's _del column, so that we can deal with
-        // deleted rows there
-        dataQuery.proj.push('_del');
-        if (!secondaryKeySet[tidKey]) {
-            dataQuery.proj.push(tidKey);
-        }
-
-        // XXX: handle the case where reqTid is not defined!
-        var reqTid = query.attributes[schema.tid];
-        var reqTime = dbu.tidNanoTime(reqTid);
-
-        // Clone the query, and create le & gt variants
-        var newerDataQuery = extend(true, {}, dataQuery);
-        // 1) select one newer index entry
-        newerDataQuery.attributes[schema.tid] = { 'ge': reqTid };
-        newerDataQuery.order = {};
-        newerDataQuery.order[schema.tid] = 'asc'; // select sibling entries
-        newerDataQuery.limit = 2; // data entry + newer entry
-        var newerRebuildRequest = req.extend({
-            query: newerDataQuery
-        });
-        var newerRebuild = self._get(newerRebuildRequest)
-        .then(function(res) {
-            var newerRebuilder = new secIndexes.IndexRebuilder(self, req, secondaryKeys, reqTime);
-            // XXX: handle the case where reqTid is not defined?
-            for (var i = res.items.length - 1; i >= 0; i--) {
-                // Process rows in reverse chronological order
-                var row = res.items[i];
-                newerRebuilder.handleRow(null, row);
-            }
-        });
-
-        var mainRebuild = new P(function(resolve, reject) {
-            try {
-                dataQuery.attributes[schema.tid] = {'le': reqTid};
-                dataQuery.limit = limit; // typically something around 3, or unlimited
-                var reqOptions = {
-                    prepare : true,
-                    fetchSize : 1000,
-                    autoPage: true
-                };
-                // Traverse the bulk of the data, in timestamp descending order
-                // (reverse chronological)
-                var dataGetReq = req.extend({
-                    query: dataQuery,
-                    columnfamily: 'data'
-                });
-                var dataGetInfo = dbu.buildGetQuery(dataGetReq);
-                var mainRebuilder = new secIndexes.IndexRebuilder(self, req, secondaryKeys, reqTime);
-                self.client.eachRow(dataGetInfo.cql, dataGetInfo.params, reqOptions,
-                    // row callback
-                    mainRebuilder.handleRow.bind(mainRebuilder),
-                    // end callback
-                    function (err, result) {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve();
-                        }
-                    }
-                );
-            } catch (e) {
-                reject (e);
-            }
-        });
-
-        return P.all([newerRebuild, mainRebuild]);
-    } else {
+    // If there are no indexes, and the retention policy is 'all' (i.e.
+    // there are no revisions to cull), then there is no need to go further.
+    if (!(indexes.length || schema.revisionRetentionPolicy.type !== 'all')) {
         return P.resolve();
     }
-};
 
+    var consistency = cass.types.consistencies.one;
+    var tidKey = schema.tid;
+
+    // Build a new request for the main data table
+    var dataQuery = {
+        table: query.table,
+        attributes: {},
+    };
+
+    // Narrow down the update to the original request's primary key. If
+    // that's empty, the entire index (within the numerical limits) will be updated.
+    schema.iKeys.forEach(function(att) {
+        if (att !== tidKey) {
+            dataQuery.attributes[att] = query.attributes[att];
+        }
+    });
+
+    // Select indexed attributes for all indexes to rebuild
+    var secondaryKeySet = {};
+    indexes.forEach(function(idx) {
+        // console.log(idx, JSON.stringify(schema.secondaryIndexes));
+        Object.keys(schema.attributeIndexes).forEach(function(att) {
+            if (!schema.iKeyMap[att] && !secondaryKeySet[att]) {
+                secondaryKeySet[att] = true;
+            }
+        });
+    });
+    var secondaryKeys = Object.keys(secondaryKeySet);
+
+    // XXX: handle the case where reqTid is not defined!
+    var reqTid = query.attributes[schema.tid];
+    var reqTime = dbu.tidNanoTime(reqTid);
+
+    // Clone the query, and create le & gt variants
+    var newerDataQuery = extend(true, {}, dataQuery);
+    // 1) select one newer index entry
+    newerDataQuery.attributes[schema.tid] = { 'ge': reqTid };
+    newerDataQuery.order = {};
+    newerDataQuery.order[schema.tid] = 'asc'; // select sibling entries
+    newerDataQuery.limit = 2; // data entry + newer entry
+    var newerRebuildRequest = req.extend({
+        query: newerDataQuery
+    });
+
+    // XXX: handle the case where reqTid is not defined?
+    var indexRebuilder = new secIndexes.IndexRebuilder(self, req, secondaryKeys, reqTime);
+    var policyManager = new revPolicy.RevisionPolicyManager(self, req, schema, reqTime);
+    var handler = new UpdateHandler([indexRebuilder, policyManager]);
+
+    // Query for a window that includes 1 newer record (if any exists), and up
+    // to 'limit' later records.  Run the list of update handlers across each
+    // matching row, in descending order.
+    return self._get(newerRebuildRequest)
+    .then(function(res) {    // Query for one record previous
+        return P.each(res.items.reverse(), handler.handleRow.bind(handler));
+    })
+    .then(function() {       // Query for 'limit' subsequent records
+        dataQuery.attributes[schema.tid] = {'lt': reqTid};
+        dataQuery.limit = limit; // typically something around 3, or unlimited
+
+        // Traverse the bulk of the data, in timestamp descending order
+        // (reverse chronological)
+        var dataGetReq = req.extend({
+            query: dataQuery,
+            columnfamily: 'data'
+        });
+        var dataGetInfo = dbu.buildGetQuery(dataGetReq);
+
+        return dbu.eachRow(
+            self.client,
+            dataGetInfo.cql,
+            dataGetInfo.params,
+            {retries: 3},
+            handler.handleRow.bind(handler)
+        );
+    });
+};
 
 DB.prototype.delete = function (domain, query) {
     return this._makeInternalRequest(domain, query.table, query)
@@ -944,6 +924,30 @@ InternalRequest.prototype.extend = function(opts) {
         req[key] = opts[key];
     });
     return req;
+};
+
+/**
+ * Convenience class for wrapping objects that perform by-row updates.
+ *
+ * @param {array} handlers; a list of objects, each of which must have a
+ * handleRow method that accepts a row object, and returns a promise.
+ */
+function UpdateHandler(handlers) {
+    this.handlers = handlers;
+}
+
+/**
+ * Invokes handleRow on each of the child handlers with the supplied row.
+ *
+ * @param  {object} row; a row object.
+ * @return a promise that resolves when the constituent promises do.
+ */
+UpdateHandler.prototype.handleRow = function(row) {
+    var r = [];
+    for (var i = 0; i < this.handlers.length; i++) {
+        r.push(this.handlers[i].handleRow(row));
+    }
+    return P.all(r);
 };
 
 module.exports = DB;

--- a/lib/db.js
+++ b/lib/db.js
@@ -543,20 +543,16 @@ DB.prototype._put = function(req) {
 /*
  * Post-put background updates
  *
- * look at sibling revisions to update the index with values that no longer
- * match, and apply the schema-specified revision retention policy.
- *   - select sibling revisions
- *   - walk results in ascending order and:
- *      - diff each row vs. preceding row
- *         - if diff: for each index affected by that diff, update _del for old
- *           value using that revision's TIMESTAMP.
- *      - apply the revision retention policy.
+ * Queries for sibling revisions (1 newer and up to 'limit' older), and applies
+ * both secondary index updates (IndexRebuilder), and the table's revision
+ * retention policy (RevisionPolicyManager). 
+ *
  * @param {object} InternalRequest; pass in an empty query to match / update
  *        all entries
  * @param {number} (optional) limit; The maximum number of entries to include
- *        in the updates.
+ *        in the updates
  * @param  {array} (optional) indexes; an array of index names to update;
- *      Default: all indexes in the schema
+ *        Default: all indexes in the schema
  */
 DB.prototype._backgroundUpdates = function(req, limit, indexes) {
     var self = this;
@@ -566,7 +562,7 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
 
     // If there are no indexes, and the retention policy is 'all' (i.e.
     // there are no revisions to cull), then there is no need to go further.
-    if (!(indexes.length || schema.revisionRetentionPolicy.type !== 'all')) {
+    if (!indexes.length && schema.revisionRetentionPolicy.type === 'all') {
         return P.resolve();
     }
 
@@ -930,7 +926,7 @@ InternalRequest.prototype.extend = function(opts) {
  * Convenience class for wrapping objects that perform by-row updates.
  *
  * @param {array} handlers; a list of objects, each of which must have a
- * handleRow method that accepts a row object, and returns a promise.
+ *        handleRow method that accepts a row object, and returns a promise.
  */
 function UpdateHandler(handlers) {
     this.handlers = handlers;
@@ -943,11 +939,9 @@ function UpdateHandler(handlers) {
  * @return a promise that resolves when the constituent promises do.
  */
 UpdateHandler.prototype.handleRow = function(row) {
-    var r = [];
-    for (var i = 0; i < this.handlers.length; i++) {
-        r.push(this.handlers[i].handleRow(row));
-    }
-    return P.all(r);
+    return P.all(this.handlers.map(function(handler) {
+        return handler.handleRow(row);
+    }));
 };
 
 module.exports = DB;

--- a/lib/db.js
+++ b/lib/db.js
@@ -931,6 +931,7 @@ function InternalRequest (opts) {
     this.consistency = opts.consistency;
     this.schema = opts.schema || null;
     this.columnfamily = opts.columnfamily || 'data';
+    this.ttl = opts.ttl || null;
 }
 
 /**

--- a/lib/db.js
+++ b/lib/db.js
@@ -939,9 +939,9 @@ function UpdateHandler(handlers) {
  * @return a promise that resolves when the constituent promises do.
  */
 UpdateHandler.prototype.handleRow = function(row) {
-    return P.all(this.handlers.map(function(handler) {
+    return P.map(this.handlers, function(handler) {
         return handler.handleRow(row);
-    }));
+    });
 };
 
 module.exports = DB;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -138,8 +138,8 @@ function _nextPage(client, query, params, pageState, retries) {
  * @param {function} function to invoke for each row result
  */
 dbu.eachRow = function eachRow(client, query, params, options, handler) {
-    function processPage(pageState, times) {
-        return _nextPage(client, query, params, pageState, times)
+    function processPage(pageState) {
+        return _nextPage(client, query, params, pageState, options.retries)
         .then(function(res) {
             return P.each(res.rows, handler)
             .then(function() {
@@ -147,23 +147,18 @@ dbu.eachRow = function eachRow(client, query, params, options, handler) {
                     return P.resolve();
                 }
                 else {
-                    return processPage(res.pageState, times);
+                    return processPage(res.pageState);
                 }
             });
         });
     }
 
-    return processPage(null, options.retries || null);
+    return processPage(null);
 };
 
 /*
  * # Section 2: Schema validation, normalization and -handling
  */
-
-function validNumber(value, from, to) {
-    var n = parseFloat(value);
-    return !isNaN(n) && n >= from && n <= to;
-}
 
 dbu.validateIndexSchema = function validateIndexSchema(schema, index) {
 
@@ -213,7 +208,6 @@ dbu.validateIndexSchema = function validateIndexSchema(schema, index) {
 dbu.validateAndNormalizeRevPolicy = function validateAndNormalizeRevPolicy(schema) {
     // FIXME: define as constants somewhere apropos
     var minGcGrace = 10;
-    var maxGcGrace = 31536000;
     var minKeep = 1;
     var maxKeep = 1000000000;
 
@@ -223,32 +217,36 @@ dbu.validateAndNormalizeRevPolicy = function validateAndNormalizeRevPolicy(schem
         policy = { type: 'all' };
     } else {
         policy = schema.revisionRetentionPolicy;
-        for (var key in policy) {
+        Object.keys(policy).forEach(function(key) {
             var val = policy[key];
             switch(key) {
             case 'type':
                 if (val !== 'all' && val !== 'latest') {
-                    throw new Error('Invalid revision retention policy type ' + val);
+                    throw new Error('Invalid revision retention policy type '+val);
                 }
                 break;
             case 'grace_ttl':
-                // valid grace_ttls are between minGcGrace and maxGcGrace seconds
-                if (!validNumber(val, minGcGrace, maxGcGrace)) {
-                    throw new Error('Invalid grace_ttl value: ' + val);
+                if (typeof(val) !== 'number') {
+                    throw new Error('grace_ttl must be a number');
                 }
-                policy.grace_ttl = parseInt(val);
+                if (val < minGcGrace) {
+                    throw new Error('grace_ttl must be a miniumum of '+minGcGrace+' seconds');
+                }
+                policy.grace_ttl = val;
                 break;
             case 'count':
-                // Valid counts are between minKeep and maxKeep
-                if (!validNumber(val, minKeep, maxKeep)) {
-                    throw new Error('Invalid count value: ' + val);
+                if (typeof(val) !== 'number') {
+                    throw new Error('count must be a number');
                 }
-                policy.count = parseInt(val);
+                if ((val < minKeep) || (val > maxKeep)) {
+                    throw new Error('count must be a value between '+minKeep+' and '+maxKeep);
+                }
+                policy.count = val;
                 break;
             default:
                 throw new Error('Unknown revision policy attribute: ' + key);
             }
-        }
+        });
     }
 
     return policy;
@@ -752,23 +750,19 @@ dbu.buildPutQuery = function(req) {
     });
 
     var using = '';
+    var usingBits = [];
     var usingParams = [];
-    var usingTypeHints = [];     // XXX: ???
-    var usingParamsKeys = [];    // XXX: ???
     if (query.timestamp && !query.if) {
-        using = ' USING TIMESTAMP ? ';
+        usingBits.push('TIMESTAMP ?');
         usingParams.push(cass.types.Long.fromNumber(Math.round(query.timestamp * 1000)));
-        usingParamsKeys.push(null);
+    }
+    if (req.ttl) {
+        usingBits.push('TTL ?');
+        usingParams.push(cass.types.Long.fromNumber(req.ttl));
     }
 
-    if (req.ttl) {
-        if (using.length) {
-            using += 'AND TTL ? ';
-        } else {
-            using += ' USING TTL ? ';
-        }
-        usingParams.push(cass.types.Long.fromNumber(req.ttl));
-        usingParamsKeys.push(null);
+    if (usingBits.length) {
+        using = ' USING ' + usingBits.join(' AND ');
     }
 
     // switch between insert & update / upsert

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -160,6 +160,11 @@ dbu.eachRow = function eachRow(client, query, params, options, handler) {
  * # Section 2: Schema validation, normalization and -handling
  */
 
+function validNumber(value, from, to) {
+    var n = parseFloat(value);
+    return !isNaN(n) && n >= from && n <= to;
+}
+
 dbu.validateIndexSchema = function validateIndexSchema(schema, index) {
 
     if (!Array.isArray(index) || !index.length) {
@@ -203,6 +208,50 @@ dbu.validateIndexSchema = function validateIndexSchema(schema, index) {
     }
 
     return index;
+};
+
+dbu.validateAndNormalizeRevPolicy = function validateAndNormalizeRevPolicy(schema) {
+    // FIXME: define as constants somewhere apropos
+    var minGcGrace = 10;
+    var maxGcGrace = 31536000;
+    var minKeep = 1;
+    var maxKeep = 1000000000;
+
+    var policy;
+
+    if (!schema.revisionRetentionPolicy) {
+        policy = { type: 'all' };
+    } else {
+        policy = schema.revisionRetentionPolicy;
+        for (var key in policy) {
+            var val = policy[key];
+            switch(key) {
+            case 'type':
+                if (val !== 'all' && val !== 'latest') {
+                    throw new Error('Invalid revision retention policy type ' + val);
+                }
+                break;
+            case 'grace_ttl':
+                // valid grace_ttls are between minGcGrace and maxGcGrace seconds
+                if (!validNumber(val, minGcGrace, maxGcGrace)) {
+                    throw new Error('Invalid grace_ttl value: ' + val);
+                }
+                policy.grace_ttl = parseInt(val);
+                break;
+            case 'count':
+                // Valid counts are between minKeep and maxKeep
+                if (!validNumber(val, minKeep, maxKeep)) {
+                    throw new Error('Invalid count value: ' + val);
+                }
+                policy.count = parseInt(val);
+                break;
+            default:
+                throw new Error('Unknown revision policy attribute: ' + key);
+            }
+        }
+    }
+
+    return policy;
 };
 
 dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
@@ -249,6 +298,8 @@ dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
     for (var index in schema.secondaryIndexes) {
         schema.secondaryIndexes[index] = dbu.validateIndexSchema(schema, schema.secondaryIndexes[index]);
     }
+    // Normalize and validate revision retention policy
+    schema.revisionRetentionPolicy = dbu.validateAndNormalizeRevPolicy(schema);
 
     // XXX: validate attributes
     return schema;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -656,11 +656,21 @@ dbu.buildPutQuery = function(req) {
 
     var using = '';
     var usingParams = [];
-    var usingTypeHints = [];
-    var usingParamsKeys = [];
+    var usingTypeHints = [];     // XXX: ???
+    var usingParamsKeys = [];    // XXX: ???
     if (query.timestamp && !query.if) {
         using = ' USING TIMESTAMP ? ';
         usingParams.push(cass.types.Long.fromNumber(Math.round(query.timestamp * 1000)));
+        usingParamsKeys.push(null);
+    }
+
+    if (req.ttl) {
+        if (using.length) {
+            using += 'AND TTL ? ';
+        } else {
+            using += ' USING TTL ? ';
+        }
+        usingParams.push(cass.types.Long.fromNumber(req.ttl));
         usingParamsKeys.push(null);
     }
 

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -7,6 +7,7 @@ var TimeUuid = cass.types.TimeUuid;
 var Integer = cass.types.Integer;
 var BigDecimal = cass.types.BigDecimal;
 var util = require('util');
+var P = require('bluebird');
 
 /*
  * Various static database utility methods
@@ -109,6 +110,51 @@ dbu.makeValidKey = function makeValidKey (key, length) {
     }
 };
 
+function _nextPage(client, query, params, pageState, retries) {
+    return client.execute_p(query, params, {
+        prepare: true,
+        fetchSize: 1000,    // XXX: hard-coded?
+        pageState: pageState,
+    })
+    .catch(function(err) {
+        if (!retries) {
+            throw err;
+        }
+        return _nextPage(client, query, params, pageState, --retries);
+    });
+}
+
+/**
+ * Async-safe Cassandra query execution
+ * 
+ * Client#eachRow in the Cassandra driver relies upon a synchronous callback
+ * to provide back-pressure during paging; This function can safely execute
+ * async callback handlers.
+ *
+ * @param   {object} cassandra-driver Client instance
+ * @param   {string} CQL query string
+ * @param    {array} CQL query params
+ * @param   {object} options map
+ * @param {function} function to invoke for each row result
+ */
+dbu.eachRow = function eachRow(client, query, params, options, handler) {
+    function processPage(pageState, times) {
+        return _nextPage(client, query, params, pageState, times)
+        .then(function(res) {
+            return P.each(res.rows, handler)
+            .then(function() {
+                if (res.pageState === null) {
+                    return P.resolve();
+                }
+                else {
+                    return processPage(res.pageState, times);
+                }
+            });
+        });
+    }
+
+    return processPage(null, options.retries || null);
+};
 
 /*
  * # Section 2: Schema validation, normalization and -handling

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -15,7 +15,7 @@ function RevisionPolicyManager(db, request, schema) {
     this.request = request;
     this.schema = schema;
     this.policy = schema.revisionRetentionPolicy;
-    this.noop = this.policy.type === 'all' ? true : false;
+    this.noop = this.policy.type === 'all';
     this.count = 0;
 }
 

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -1,0 +1,57 @@
+"use strict";
+
+var dbu = require('./dbutils');
+var P = require('bluebird');
+
+/**
+ * Applies a revision retention policy to a sequence of rows.
+ *
+ * @param {object} db; instance of DB
+ * @param {object} request; request to use as baseline
+ * @param {object} schema; the table schema
+ */
+function RevisionPolicyManager(db, request, schema) {
+    this.db = db;
+    this.request = request;
+    this.schema = schema;
+    this.policy = schema.revisionRetentionPolicy;
+    this.noop = this.policy.type === 'all' ? true : false;
+    this.count = 0;
+}
+
+/**
+ * Process one row in the sequence.
+ *
+ * @param {object} row; a row object.
+ * @return a promise that resolves when the corresponding update is complete.
+ */
+RevisionPolicyManager.prototype.handleRow = function(row) {
+    var self = this;
+
+    if (self.noop) {
+        return P.resolve();
+    }
+
+    if (self.count < self.policy.count) {
+        self.count++;
+        return P.resolve();
+    }
+
+    var request = self.request.extend({ ttl: self.policy.grace_ttl });
+    Object.keys(request.query.attributes).forEach(function(key) {
+        request.query.attributes[key] = row[key];
+    });
+    request.query.timestamp = null;
+
+    var query = dbu.buildPutQuery(request);
+    var queryOptions = { consistency: request.consistency, prepare: true };
+
+    return self.db.client.execute_p(query.cql, query.params, queryOptions)
+    .catch(function(e) {
+        self.db.log('error/table/cassandra/revisionRetentionPolicyUpdate', e);
+    });
+};
+
+module.exports = {
+    RevisionPolicyManager: RevisionPolicyManager
+};

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -55,7 +55,7 @@ IndexRebuilder.prototype.diffRow = function (row) {
 };
 
 
-IndexRebuilder.prototype.handleRow = function (n, row) {
+IndexRebuilder.prototype.handleRow = function (row) {
     if (!this.prevRow) {
         // In normal operation there is no need to update the index for the
         // first row, as we are only interested in diffs, and the new data was

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -54,7 +54,14 @@ IndexRebuilder.prototype.diffRow = function (row) {
     };
 };
 
-
+/**
+ * Diff each row against the preceding row. If they differ, then for each index
+ * affected by the difference, update _del for old value using the revision's
+ * timestamp.
+ *
+ * @param {object} row; a row object
+ * @return a promise that resolves when the update is complete
+ */
 IndexRebuilder.prototype.handleRow = function (row) {
     if (!this.prevRow) {
         // In normal operation there is no need to update the index for the

--- a/test/index.js
+++ b/test/index.js
@@ -462,7 +462,8 @@ describe('DB backend', function() {
                     table: "unversionedSecondaryIndexTable",
                     attributes: {
                         key: "another test",
-                        uri: "a uri"
+                        uri: "a uri",
+                        body: "a body"
                     },
                 }
             })

--- a/test/revision_policies.js
+++ b/test/revision_policies.js
@@ -1,0 +1,130 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var assert = require('assert');
+var cass = require('cassandra-driver');
+var dbu = require('../lib/dbutils.js');
+var fs = require('fs');
+var makeClient = require('../lib/index');
+var TimeUuid = cass.types.TimeUuid;
+var yaml = require('js-yaml');
+
+describe('MVCC revision policies', function() {
+    var db;
+    before(function() {
+        return makeClient({
+            log: function(level, info) {
+                if (!/^info|verbose|debug|trace|warn/.test(level)) {
+                    console.log(level, info);
+                }
+            },
+            conf: yaml.safeLoad(fs.readFileSync(__dirname + '/test_router.conf.yaml'))
+        })
+        .then(function(newDb) {
+            db = newDb;
+        })
+        .then(function() {
+            return db.createTable("domains_test", {
+                table: 'revPolicyLatestTest',
+                options: { durability: 'low' },
+                attributes: {
+                    title: 'string',
+                    rev: 'int',
+                    tid: 'timeuuid',
+                    comment: 'string'
+                },
+                index: [
+                    { attribute: 'title', type: 'hash' },
+                    { attribute: 'rev', type: 'range', order: 'desc' },
+                    { attribute: 'tid', type: 'range', order: 'desc' }
+                ],
+                secondaryIndexes: {
+                    by_rev : [
+                        { attribute: 'rev', type: 'hash' },
+                        { attribute: 'tid', type: 'range', order: 'desc' },
+                        { attribute: 'title', type: 'range', order: 'asc' },
+                        { attribute: 'comment', type: 'proj' }
+                    ]
+                },
+                revisionRetentionPolicy: {
+                    type: 'latest',
+                    count: 2,
+                    grace_ttl: 10
+                }
+            })
+            .then(function(response) {
+                assert.deepEqual(response.status, 201);
+            });
+        });
+    });
+
+    after(function() {
+        return db.dropTable("domains_test", 'revPolicyLatestTest');
+    });
+
+    it('sets a TTL on all but the latest N entries', function() {
+        this.timeout(12000);
+        return db.put('domains_test', {
+            table: 'revPolicyLatestTest',
+            consistency: 'localQuorum',
+            attributes: {
+                title: 'Revisioned',
+                rev: 1000,
+                tid: dbu.testTidFromDate(new Date("2015-04-01 12:00:00-0500")),
+                comment: 'once'
+            }
+        })
+        .then(function(response) {
+            assert.deepEqual(response.status, 201);
+        })
+        .then(function() {
+            return db.put('domains_test', {
+                table: 'revPolicyLatestTest',
+                consistency: 'localQuorum',
+                attributes: {
+                    title: 'Revisioned',
+                    rev: 1000,
+                    tid: dbu.testTidFromDate(new Date("2015-04-01 12:00:01-0500")),
+                    comment: 'twice'
+                }
+            });
+        })
+        .then(function(response) {
+            assert.deepEqual(response, {status:201});
+            
+            return db.put('domains_test', {
+                table: 'revPolicyLatestTest',
+                consistency: 'localQuorum',
+                attributes: {
+                    title: 'Revisioned',
+                    rev: 1000,
+                    tid: dbu.testTidFromDate(new Date("2015-04-01 12:00:02-0500")),
+                    comment: 'thrice'
+                }
+            });
+        })
+        // Delay long enough for the background updates to complete, then
+        // for the grace_ttl to expire.
+        .delay(11000)
+        .then(function(response) {
+            assert.deepEqual(response, {status: 201});
+            
+            return db.get('domains_test', {
+                table: 'revPolicyLatestTest',
+                attributes: {
+                    title: 'Revisioned',
+                    rev: 1000,
+                },
+            });
+        })
+        .then(function(response) {
+            assert.ok(response);
+            assert.ok(response.items);
+            assert.deepEqual(response.items.length, 2);
+        });
+    });
+
+});
+


### PR DESCRIPTION
This branch:

 * implements a test case for a policy of `latest`
 * adds support for CQL generation of `USING TTL` queries
 * adds an async-safe utility method for performing arbitrarily large Cassandra queries, and paging through the results
 * adds `RevisionPolicyManager` (currently supports policy types of `all`, and `latest`), and wires it into a refactored `DB#_rebuildIndexes` (renamed `DB#_backgroundUpdates`).

See: https://phabricator.wikimedia.org/T94524