### PR TITLE
Don't set the default retention policy in the schema itself

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -545,7 +545,7 @@ DB.prototype._put = function(req) {
  *
  * Queries for sibling revisions (1 newer and up to 'limit' older), and applies
  * both secondary index updates (IndexRebuilder), and the table's revision
- * retention policy (RevisionPolicyManager). 
+ * retention policy (RevisionPolicyManager).
  *
  * @param {object} InternalRequest; pass in an empty query to match / update
  *        all entries

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -126,7 +126,7 @@ function _nextPage(client, query, params, pageState, retries) {
 
 /**
  * Async-safe Cassandra query execution
- * 
+ *
  * Client#eachRow in the Cassandra driver relies upon a synchronous callback
  * to provide back-pressure during paging; This function can safely execute
  * async callback handlers.
@@ -213,9 +213,7 @@ dbu.validateAndNormalizeRevPolicy = function validateAndNormalizeRevPolicy(schem
 
     var policy;
 
-    if (!schema.revisionRetentionPolicy) {
-        policy = { type: 'all' };
-    } else {
+    if (schema.revisionRetentionPolicy) {
         policy = schema.revisionRetentionPolicy;
         Object.keys(policy).forEach(function(key) {
             var val = policy[key];
@@ -569,6 +567,9 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema, isMetaCF) {
     }
     psi.attributeIndexes = attributeIndexes;
 
+    if (!psi.revisionRetentionPolicy) {
+        psi.revisionRetentionPolicy = { type: 'all' };
+    }
 
     // define a 'hash' string representation for the schema for quick schema
     // comparisons.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "dependencies": {
     "async": "0.x.x",
     "bluebird": "~2.3.10",


### PR DESCRIPTION
Instead, add the default in makeSchemaInfo. This makes new schemas compatible
with existing schemas, and thus avoids breakage or the need for schema
migration.