### PR TITLE
revision retention policy schema migration

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function RBCassandra (options) {
         operations: {
             createTable: this.createTable.bind(this),
             dropTable: this.dropTable.bind(this),
-            getTable: this.getTable.bind(this),
+            getTableSchema: this.getTableSchema.bind(this),
             get: this.get.bind(this),
             put: this.put.bind(this)
         }
@@ -147,9 +147,9 @@ RBCassandra.prototype.dropTable = function (rb, req) {
     });
 };
 
-RBCassandra.prototype.getTable = function (rb, req) {
+RBCassandra.prototype.getTableSchema = function (rb, req) {
     var domain = req.params.domain;
-    return this.store.getTable(domain, req.params.table)
+    return this.store.getTableSchema(domain, req.params.table)
     .then(function(res) {
         return {
             status: 200,

--- a/index.js
+++ b/index.js
@@ -161,8 +161,8 @@ RBCassandra.prototype.getTableSchema = function (rb, req) {
         return {
             status: 500,
             body: {
-                type: 'table_query_error',
-                title: 'Internal error in Cassandra table storage backend',
+                type: 'schema_query_error',
+                title: 'Internal error querying table schema in Cassandra storage backend',
                 stack: e.stack,
                 err: e,
                 req: req

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function RBCassandra (options) {
         operations: {
             createTable: this.createTable.bind(this),
             dropTable: this.dropTable.bind(this),
+            getTable: this.getTable.bind(this),
             get: this.get.bind(this),
             put: this.put.bind(this)
         }
@@ -137,6 +138,30 @@ RBCassandra.prototype.dropTable = function (rb, req) {
             status: 500,
             body: {
                 type: 'delete_error',
+                title: 'Internal error in Cassandra table storage backend',
+                stack: e.stack,
+                err: e,
+                req: req
+            }
+        };
+    });
+};
+
+RBCassandra.prototype.getTable = function (rb, req) {
+    var domain = req.params.domain;
+    return this.store.getTable(domain, req.params.table)
+    .then(function(res) {
+        return {
+            status: 200,
+            headers: { etag: res.tid.toString() },
+            body: res.schema
+        };
+    })
+    .catch(function(e) {
+        return {
+            status: 500,
+            body: {
+                type: 'table_query_error',
                 title: 'Internal error in Cassandra table storage backend',
                 stack: e.stack,
                 err: e,

--- a/lib/db.js
+++ b/lib/db.js
@@ -21,11 +21,7 @@ function DB (client, options) {
     // cassandra client
     this.client = client;
 
-
-    // cache keyspace -> schema
-    this.schemaCache = {};
-    this.keyspaceSchemaCache = {};
-    this.keyspaceNameCache = {};
+    this._initSchemaCache();
 
     /* Process the array of storage groups declared in the config */
     this.storageGroups = this._buildStorageGroups(options.conf.storage_groups);
@@ -33,6 +29,12 @@ function DB (client, options) {
     this.storageGroupsCache = {};
 }
 
+DB.prototype._initSchemaCache = function() {
+    // cache keyspace -> schema
+    this.schemaCache = {};
+    this.keyspaceSchemaCache = {};
+    this.keyspaceNameCache = {};
+};
 
 /**
  * Set up internal request-related information and wrap it into an
@@ -723,8 +725,8 @@ DB.prototype.createTable = function (domain, query) {
                     });
                     return self._put(putReq)
                     .then(function() {
-                        var cacheKey = JSON.stringify([domain,query.table]);
-                        self.schemaCache[cacheKey] = newSchemaInfo;
+                        // Force a cache update on subsequent requests
+                        self._initSchemaCache();
                         return { status: 201 };
                     });
                 })
@@ -925,7 +927,7 @@ DB.prototype.dropTable = function (domain, table) {
             {consistency: this.defaultConsistency});
 };
 
-DB.prototype.getTable = function(domain, table) {
+DB.prototype.getTableSchema = function(domain, table) {
     var cacheKey = JSON.stringify([domain,table]);
     var req = new InternalRequest({
         domain: domain,

--- a/lib/db.js
+++ b/lib/db.js
@@ -896,6 +896,33 @@ DB.prototype.dropTable = function (domain, table) {
             {consistency: this.defaultConsistency});
 };
 
+DB.prototype.getTable = function(domain, table) {
+    var cacheKey = JSON.stringify([domain,table]);
+    var req = new InternalRequest({
+        domain: domain,
+        table: table,
+        keyspace: this.keyspaceNameCache[cacheKey] || this._keyspaceName(domain, table),
+        query: { attributes: { key: 'schema' }, limit: 1 },
+        consistency: this.defaultConsistency,
+        columnfamily: 'meta',
+        schema: this.infoSchemaInfo
+    });
+    return this._get(req)
+    .then(function(response) {
+        if (!response.items.length) {
+            throw new dbu.HTTPError({
+                status: 404,
+                body: {
+                    type: 'notfound',
+                    title: 'the requested table schema was not found'
+                }
+            });
+        }
+        var item = response.items[0];
+        return { tid: item.tid, schema: JSON.parse(item.value) };
+    });
+};
+
 /**
  * Wrap common internal request state
  */

--- a/lib/db.js
+++ b/lib/db.js
@@ -7,7 +7,7 @@ var extend = require('extend');
 var dbu = require('./dbutils');
 var cassID = dbu.cassID;
 var revPolicy = require('./revisionPolicy');
-var SchemaMigrator = require('./schemaMigration').SchemaMigrator;
+var SchemaMigrator = require('./schemaMigration');
 var secIndexes = require('./secondaryIndexes');
 
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -7,6 +7,7 @@ var extend = require('extend');
 var dbu = require('./dbutils');
 var cassID = dbu.cassID;
 var revPolicy = require('./revisionPolicy');
+var SchemaMigrator = require('./schemaMigration').SchemaMigrator;
 var secIndexes = require('./secondaryIndexes');
 
 
@@ -671,11 +672,10 @@ DB.prototype.createTable = function (domain, query) {
     })
     .then(function(req) {
         var currentSchemaInfo = req.schema;
+
         // Validate and normalize the schema
         var newSchema = dbu.validateAndNormalizeSchema(req.query);
-
         var newSchemaInfo = dbu.makeSchemaInfo(newSchema);
-
 
         if (currentSchemaInfo) {
             // Table already exists
@@ -694,14 +694,43 @@ DB.prototype.createTable = function (domain, query) {
                     status: 201
                 };
             } else {
-                throw new dbu.HTTPError({
-                    status: 400,
-                    body: {
-                        type: 'bad_request',
-                        title: 'The table already exists, and its schema cannot be upgraded to the requested schema.',
-                        keyspace: req.keyspace,
-                        schema: newSchema
-                    }
+                var migrator;
+                try {
+                    migrator = new SchemaMigrator(self, currentSchemaInfo, newSchemaInfo);
+                }
+                catch (error) {
+                    throw new dbu.HTTPError({
+                        status: 400,
+                        body: {
+                            type: 'bad_request',
+                            title: 'The table already exists, and its schema cannot be upgraded to the requested schema ('+error+').',
+                            keyspace: req.keyspace,
+                            schema: newSchema
+                        }
+                    });
+                }
+                return migrator.migrate()
+                .then(function() {
+                    var putReq = req.extend({
+                        columnfamily: 'meta',
+                        schema: self.infoSchemaInfo,
+                        query: {
+                            attributes: {
+                                key: 'schema',
+                                value: newSchema
+                            }
+                        }
+                    });
+                    return self._put(putReq)
+                    .then(function() {
+                        var cacheKey = JSON.stringify([domain,query.table]);
+                        self.schemaCache[cacheKey] = newSchemaInfo;
+                        return { status: 201 };
+                    });
+                })
+                .catch(function(error) {
+                    self.log('error/cassandra/table_update', error);
+                    throw error;
                 });
             }
         }

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -318,9 +318,7 @@ dbu.validateAndNormalizeRevPolicy = function validateAndNormalizeRevPolicy(schem
 
 dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
     if (!schema.version) {
-        schema.version = 1;
-    } else if (schema.version !== 1) {
-        throw new Error("Schema version 1 expected, got " + schema.version);
+        schema.version = 0;
     }
 
     // Check options

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -8,6 +8,7 @@ var Integer = cass.types.Integer;
 var BigDecimal = cass.types.BigDecimal;
 var util = require('util');
 var P = require('bluebird');
+var stringify = require('json-stable-stringify');
 
 /*
  * Various static database utility methods
@@ -113,62 +114,11 @@ dbu.makeValidKey = function makeValidKey (key, length) {
 /**
  * Create a schema hash string.
  *
- * This is a purpose-built version of JSON.stringify, that is (more)
- * deterministic.  It is intended for schema objects, and may or may not
- * work as advertised on others.
- *
- * Note: The proper functioning of this method is dependent on
- * JSON.stringify creating identical output for two or more matching
- * objects with matching assignment order.  The docs would suggest this is
- * an unsafe assumption, but in practice it seems to be true.
- *
  * @param  {object} schema; a schema object
  * @return {string} the schema serialized to string
  */
 dbu.makeSchemaHash = function makeSchemaHash(schema) {
-    // Object comparator function for sorting by the value of the highest
-    // sorting attribute.
-    function cmp(a, b) {
-        if (typeof(a) === 'object' && typeof(b) === 'object') {
-            var key = Object.keys(a).sort()[0];
-            if (key && b.hasOwnProperty(key)) {
-                if (a[key] > b[key]) {
-                    return 1;
-                }
-                if (a[key] < b[key]) {
-                    return -1;
-                }
-            }
-        }
-        return 0;
-    }
-
-    // Creates an object with the attributes assigned in sorted order; The
-    // expectation is that two normalized objects that are equal can be
-    // serialized to identical strings using JSON.stringify.
-    function normalize(obj) {
-        if (!(obj instanceof Object)) {
-            return obj;
-        }
-        var copy = {};
-        Object.keys(obj).sort().forEach(function(key) {
-            if (obj[key] instanceof Array) {
-                copy[key] = [];
-                obj[key].sort(cmp).forEach(function(item) {
-                    copy[key] = normalize(obj[key]);
-                });
-            }
-            else if (typeof(obj[key]) === 'object') {
-                copy[key] = normalize(obj[key]);
-            }
-            else {
-                copy[key] = obj[key];
-            }
-        });
-        return copy;
-    }
-
-    return JSON.stringify(normalize(extend(true, {}, schema)));
+    return stringify(schema);
 };
 
 function _nextPage(client, query, params, pageState, retries) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -126,11 +126,6 @@ dbu.makeValidKey = function makeValidKey (key, length) {
  * @return {string} the schema serialized to string
  */
 dbu.makeSchemaHash = function makeSchemaHash(schema) {
-    // Create a copy with no references to the original
-    function clone(obj) {
-        return JSON.parse(JSON.stringify(obj));
-    }
-
     // Object comparator function for sorting by the value of the highest
     // sorting attribute.
     function cmp(a, b) {
@@ -152,7 +147,7 @@ dbu.makeSchemaHash = function makeSchemaHash(schema) {
     // expectation is that two normalized objects that are equal can be
     // serialized to identical strings using JSON.stringify.
     function normalize(obj) {
-        if ((obj === null) || (obj === undefined)) {
+        if (!(obj instanceof Object)) {
             return obj;
         }
         var copy = {};
@@ -173,7 +168,7 @@ dbu.makeSchemaHash = function makeSchemaHash(schema) {
         return copy;
     }
 
-    return JSON.stringify(normalize(clone(schema)));
+    return JSON.stringify(normalize(extend(true, {}, schema)));
 };
 
 function _nextPage(client, query, params, pageState, retries) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -263,7 +263,7 @@ dbu.validateAndNormalizeRevPolicy = function validateAndNormalizeRevPolicy(schem
 
 dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
     if (!schema.version) {
-        schema.version = 0;
+        schema.version = 1;
     }
 
     // Check options

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -110,6 +110,72 @@ dbu.makeValidKey = function makeValidKey (key, length) {
     }
 };
 
+/**
+ * Create a schema hash string.
+ *
+ * This is a purpose-built version of JSON.stringify, that is (more)
+ * deterministic.  It is intended for schema objects, and may or may not
+ * work as advertised on others.
+ *
+ * Note: The proper functioning of this method is dependent on
+ * JSON.stringify creating identical output for two or more matching
+ * objects with matching assignment order.  The docs would suggest this is
+ * an unsafe assumption, but in practice it seems to be true.
+ *
+ * @param  {object} schema; a schema object
+ * @return {string} the schema serialized to string
+ */
+dbu.makeSchemaHash = function makeSchemaHash(schema) {
+    // Create a copy with no references to the original
+    function clone(obj) {
+        return JSON.parse(JSON.stringify(obj));
+    }
+
+    // Object comparator function for sorting by the value of the highest
+    // sorting attribute.
+    function cmp(a, b) {
+        if (typeof(a) === 'object' && typeof(b) === 'object') {
+            var key = Object.keys(a).sort()[0];
+            if (key && b.hasOwnProperty(key)) {
+                if (a[key] > b[key]) {
+                    return 1;
+                }
+                if (a[key] < b[key]) {
+                    return -1;
+                }
+            }
+        }
+        return 0;
+    }
+
+    // Creates an object with the attributes assigned in sorted order; The
+    // expectation is that two normalized objects that are equal can be
+    // serialized to identical strings using JSON.stringify.
+    function normalize(obj) {
+        if ((obj === null) || (obj === undefined)) {
+            return obj;
+        }
+        var copy = {};
+        Object.keys(obj).sort().forEach(function(key) {
+            if (obj[key] instanceof Array) {
+                copy[key] = [];
+                obj[key].sort(cmp).forEach(function(item) {
+                    copy[key] = normalize(obj[key]);
+                });
+            }
+            else if (typeof(obj[key]) === 'object') {
+                copy[key] = normalize(obj[key]);
+            }
+            else {
+                copy[key] = obj[key];
+            }
+        });
+        return copy;
+    }
+
+    return JSON.stringify(normalize(clone(schema)));
+};
+
 function _nextPage(client, query, params, pageState, retries) {
     return client.execute_p(query, params, {
         prepare: true,
@@ -573,7 +639,7 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema, isMetaCF) {
 
     // define a 'hash' string representation for the schema for quick schema
     // comparisons.
-    psi.hash = JSON.stringify(psi);
+    psi.hash = dbu.makeSchemaHash(psi);
 
     return psi;
 };
@@ -966,7 +1032,5 @@ dbu.getTableCompressionCQL = function(compressions) {
     }
     return '';
 };
-
-
 
 module.exports = dbu;

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -1,9 +1,10 @@
 "use strict";
 
+var dbu = require('./dbutils');
 var P = require('bluebird');
 var util = require('util');
 
-var hash = JSON.stringify;
+var hash = dbu.makeSchemaHash;
 
 /**
  * Base migration handler for unsupported schema

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -1,0 +1,170 @@
+"use strict";
+
+var P = require('bluebird');
+
+var hash = JSON.stringify;
+
+/**
+ * Base migration handler for unsupported schema
+ */
+function Unsupported(attr, current, proposed) {
+    this.attr = attr;
+    this.current = current;
+    this.proposed = proposed;
+}
+
+Unsupported.prototype.validate = function() {
+    if (hash(this.current) !== hash(this.proposed)) {
+        throw new Error(this.attr + ' attribute migrations are unsupported');
+    }
+};
+
+Unsupported.prototype.migrate = function() {
+    return P.resolve();
+};
+
+/**
+ * Table name handler
+ */
+function Table(db, current, proposed) {
+    Unsupported.call(this, 'table', current, proposed);
+}
+
+Table.prototype = Object.create(Unsupported.prototype);
+
+/**
+ * options object migration handler
+ */
+function Options(db, current, proposed) {
+    Unsupported.call(this, 'options', current, proposed);
+}
+
+Options.prototype = Object.create(Unsupported.prototype);
+
+/**
+ * attributes object migration handler
+ */
+function Attributes(db, current, proposed) {
+    Unsupported.call(this, 'attributes', current, proposed);
+}
+
+Attributes.prototype = Object.create(Unsupported.prototype);
+
+/**
+ * Index definition migrations
+ */
+function Index(db, current, proposed) {
+    Unsupported.call(this, 'index', current, proposed);
+}
+
+Index.prototype = Object.create(Unsupported.prototype);
+
+/**
+ * Secondary index definition migrations
+ */
+function SecondaryIndexes(db, current, proposed) {
+    Unsupported.call(this, 'secondaryIndexes', current, proposed);
+}
+
+SecondaryIndexes.prototype = Object.create(Unsupported.prototype);
+
+/**
+ * Revision retention policy definiation migrations
+ */
+function RevisionRetentionPolicy(db, current, proposed) {
+    this.db = db;
+    this.current = current;
+    this.proposed = proposed;
+}
+
+// Nothing to do; There are no constraints on moving from one (valid)
+// retention policy, to another.
+RevisionRetentionPolicy.prototype.validate = function() {
+    return;
+};
+
+// Nothing to do.
+RevisionRetentionPolicy.prototype.migrate = function() {
+    this.db.log('warn/schemaMigration/revisionRetentionPolicy', 'applying', this.proposed);
+    return P.resolve();
+};
+
+/**
+ * Version handling
+ */
+function Version(db, current, proposed) {
+    this.db = db;
+    this.current = current;
+    this.proposed = proposed;
+}
+
+// versions must be monotonically increasing.
+Version.prototype.validate = function() {
+    if (this.current >= this.proposed) {
+        throw new Error('new version must be higher than previous');
+    }
+};
+
+Version.prototype.migrate = function() {
+    this.db.log('warn/schemaMigration/version', this.current, '->', this.proposed);
+    return P.resolve();
+};
+
+var migrationHandlers = {
+    table: Table,
+    options: Options,
+    attributes: Attributes,
+    index: Index,
+    secondaryIndexes: SecondaryIndexes,
+    revisionRetentionPolicy: RevisionRetentionPolicy,
+    version: Version
+};
+
+/**
+ * Schema migration.
+ * 
+ * Accepts arguments for the current, and proposed schema as schema-info
+ * objects (hint: the output of dbu#makeSchemaInfo).  Validation of the
+ * proposed migration is performed, and an exception raised if necessary.
+ * Note: The schemas themselves are not validated, only the migration; schema
+ * input should be validated ahead of time using
+ * dbu#validateAndNormalizeSchema).
+ *
+ * @param  {object] client; an instance of DB
+ * @param  {object} schemaFrom; current schema info object.
+ * @param  {object} schemaTo; proposed schema info object.
+ * @throws  {Error} if the proposed migration fails to validate
+ */
+function SchemaMigrator(db, current, proposed) {
+    this.db = db;
+    this.current = current;
+    this.proposed = proposed;
+
+    var self = this;
+    this.migrators = Object.keys(migrationHandlers).map(function(key) {
+        return new migrationHandlers[key](db, self.current[key], self.proposed[key]);
+    });
+
+    this._validate();
+}
+
+SchemaMigrator.prototype._validate = function() {
+    this.migrators.forEach(function(migrator) {
+        migrator.validate();
+    });
+};
+
+/**
+ * Perform any required migration tasks.
+ *
+ * @return a promise that resolves when the migration tasks are complete
+ */
+SchemaMigrator.prototype.migrate = function() {
+    return P.each(this.migrators, function(migrator) {
+        return migrator.migrate();
+    });
+};
+
+module.exports = {
+    SchemaMigrator: SchemaMigrator
+};

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var P = require('bluebird');
+var util = require('util');
 
 var hash = JSON.stringify;
 
@@ -30,7 +31,7 @@ function Table(db, current, proposed) {
     Unsupported.call(this, 'table', current, proposed);
 }
 
-Table.prototype = Object.create(Unsupported.prototype);
+util.inherits(Table, Unsupported);
 
 /**
  * options object migration handler
@@ -39,7 +40,7 @@ function Options(db, current, proposed) {
     Unsupported.call(this, 'options', current, proposed);
 }
 
-Options.prototype = Object.create(Unsupported.prototype);
+util.inherits(Options, Unsupported);
 
 /**
  * attributes object migration handler
@@ -48,7 +49,7 @@ function Attributes(db, current, proposed) {
     Unsupported.call(this, 'attributes', current, proposed);
 }
 
-Attributes.prototype = Object.create(Unsupported.prototype);
+util.inherits(Attributes, Unsupported);
 
 /**
  * Index definition migrations
@@ -57,7 +58,7 @@ function Index(db, current, proposed) {
     Unsupported.call(this, 'index', current, proposed);
 }
 
-Index.prototype = Object.create(Unsupported.prototype);
+util.inherits(Index, Unsupported);
 
 /**
  * Secondary index definition migrations
@@ -66,7 +67,7 @@ function SecondaryIndexes(db, current, proposed) {
     Unsupported.call(this, 'secondaryIndexes', current, proposed);
 }
 
-SecondaryIndexes.prototype = Object.create(Unsupported.prototype);
+util.inherits(SecondaryIndexes, Unsupported);
 
 /**
  * Revision retention policy definiation migrations
@@ -165,6 +166,4 @@ SchemaMigrator.prototype.migrate = function() {
     });
 };
 
-module.exports = {
-    SchemaMigrator: SchemaMigrator
-};
+module.exports = SchemaMigrator;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "bluebird": "~2.3.10",
     "cassandra-driver": "~2.0.0",
     "extend": "^2.0.0",
+    "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "js-yaml": "^3.2.5"
   },
   "repository": {

--- a/table.yaml
+++ b/table.yaml
@@ -14,6 +14,8 @@ paths:
       operationId: createTable
     delete:
       operationId: dropTable
+    get:
+      operationId: getTable
 
   /{table}/{+rest}:
     get: *get

--- a/table.yaml
+++ b/table.yaml
@@ -15,7 +15,7 @@ paths:
     delete:
       operationId: dropTable
     get:
-      operationId: getTable
+      operationId: getTableSchema
 
   /{table}/{+rest}:
     get: *get

--- a/test/dbutils.js
+++ b/test/dbutils.js
@@ -1,0 +1,69 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var assert = require('assert');
+var dbu = require('../lib/dbutils');
+
+var testTable0a = {
+    domain: 'restbase.cassandra.test.local',
+    table: 'testTable0',
+    options: { durability: 'low' },
+    attributes: {
+        title: 'string',
+        rev: 'int',
+        tid: 'timeuuid',
+        comment: 'string',
+        author: 'string'
+    },
+    index: [
+        { attribute: 'title', type: 'hash' },
+        { attribute: 'rev', type: 'range', order: 'desc' },
+        { attribute: 'tid', type: 'range', order: 'desc' }
+    ],
+    secondaryIndexes: {
+        by_rev : [
+            { attribute: 'rev', type: 'hash' },
+            { attribute: 'tid', type: 'range', order: 'desc' },
+            { attribute: 'title', type: 'range', order: 'asc' },
+            { attribute: 'comment', type: 'proj' }
+        ]
+    }
+};
+
+// Same as testTable0a, but with a different definition ordering.
+var testTable0b = {
+    table: 'testTable0',
+    options: { durability: 'low' },
+    attributes: {
+        title: 'string',
+        rev: 'int',
+        tid: 'timeuuid',
+        author: 'string',
+        comment: 'string'
+    },
+    domain: 'restbase.cassandra.test.local',
+    secondaryIndexes: {
+        by_rev : [
+            { attribute: 'rev', type: 'hash' },
+            { attribute: 'tid', type: 'range', order: 'desc' },
+            { attribute: 'comment', type: 'proj' },
+            { attribute: 'title', type: 'range', order: 'asc' },
+        ]
+    },
+    index: [
+        { attribute: 'rev', type: 'range', order: 'desc' },
+        { attribute: 'tid', type: 'range', order: 'desc' },
+        { attribute: 'title', type: 'hash' },
+    ]
+};
+
+
+describe('DB utilities', function() {
+    it('generates deterministic hash', function() {
+        assert.deepEqual(
+            dbu.makeSchemaHash(testTable0a),
+            dbu.makeSchemaHash(testTable0b));
+    });
+});

--- a/test/dbutils.js
+++ b/test/dbutils.js
@@ -48,14 +48,14 @@ var testTable0b = {
         by_rev : [
             { attribute: 'rev', type: 'hash' },
             { attribute: 'tid', type: 'range', order: 'desc' },
-            { attribute: 'comment', type: 'proj' },
             { attribute: 'title', type: 'range', order: 'asc' },
+            { attribute: 'comment', type: 'proj' }
         ]
     },
     index: [
-        { attribute: 'rev', type: 'range', order: 'desc' },
-        { attribute: 'tid', type: 'range', order: 'desc' },
         { attribute: 'title', type: 'hash' },
+        { attribute: 'rev', type: 'range', order: 'desc' },
+        { attribute: 'tid', type: 'range', order: 'desc' }
     ]
 };
 

--- a/test/schema_migrations.js
+++ b/test/schema_migrations.js
@@ -1,0 +1,114 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var assert = require('assert');
+var fs = require('fs');
+var makeClient = require('../lib/index');
+var router = require('./test_router.js');
+var yaml = require('js-yaml');
+
+var hash = JSON.stringify;
+
+function clone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+}
+
+var testTable0 = {
+    domain: 'restbase.cassandra.test.local',
+    table: 'testTable0',
+    options: { durability: 'low' },
+    attributes: {
+        title: 'string',
+        rev: 'int',
+        tid: 'timeuuid',
+        comment: 'string',
+        author: 'string'
+    },
+    index: [
+        { attribute: 'title', type: 'hash' },
+        { attribute: 'rev', type: 'range', order: 'desc' },
+        { attribute: 'tid', type: 'range', order: 'desc' }
+    ],
+    secondaryIndexes: {
+        by_rev : [
+            { attribute: 'rev', type: 'hash' },
+            { attribute: 'tid', type: 'range', order: 'desc' },
+            { attribute: 'title', type: 'range', order: 'asc' },
+            { attribute: 'comment', type: 'proj' }
+        ]
+    }
+};
+
+describe('Schema migration', function() {
+    before(function() {
+        return router.makeRouter();
+    });
+    after(function() {
+        return router.request({
+            uri: '/restbase.cassandra.test.local/sys/table/testTable0',
+            method: 'DELETE',
+            body: {}
+        });
+    });
+
+    it('migrates revision retention policies', function() {
+        var newSchema = clone(testTable0);
+        newSchema.version = 1;
+        newSchema.revisionRetentionPolicy = {
+            type: 'latest',
+            count: 5,
+            grace_ttl: 86400
+        };
+
+        return router.request({
+            uri: '/restbase.cassandra.test.local/sys/table/testTable0',
+            method: 'PUT',
+            body: testTable0
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 201);
+
+            return router.request({
+                uri: '/restbase.cassandra.test.local/sys/table/testTable0',
+                method: 'PUT',
+                body: newSchema
+            });
+        })
+        .then(function(response) {
+            assert.ok(response);
+            assert.deepEqual(response.status, 201);
+
+            return router.request({
+                uri: '/restbase.cassandra.test.local/sys/table/testTable0',
+                method: 'GET',
+            });
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 200);
+            assert.deepEqual(hash(response.body), hash(newSchema));
+        });
+    });
+
+    it('requires monotonically increasing versions', function() {
+        var newSchema = clone(testTable0);
+        newSchema.version = 1;
+        newSchema.revisionRetentionPolicy = { type: 'all' };
+
+        return router.request({
+            uri: '/restbase.cassandra.test.local/sys/table/testTable0',
+            method: 'PUT',
+            body: newSchema
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 400);
+            assert.ok(
+                /version must be higher/.test(response.body.title),
+                'error message looks wrong');
+        });
+    });
+});

--- a/test/schema_migrations.js
+++ b/test/schema_migrations.js
@@ -67,7 +67,7 @@ describe('Schema migration', function() {
 
     it('migrates revision retention policies', function() {
         var newSchema = clone(testTable0);
-        newSchema.version = 1;
+        newSchema.version = 2;
         newSchema.revisionRetentionPolicy = {
             type: 'latest',
             count: 5,


### PR DESCRIPTION
This makes it possible to migrate from one revision retention policy to another (or from none / the default).  More generally, it provides the framework by which additional schema migration can be implemented as well.

Note: In the absence of an explicitly defined schema version, the new default becomes 0.  This means that existing RESTBase installations will need to have their schema versions explicity set to 1, (that will be handled in a separate pull request against wikimedia/restbase).

See: https://phabricator.wikimedia.org/T96612