### PR TITLE
schema attribute addition/removal

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -698,7 +698,7 @@ DB.prototype.createTable = function (domain, query) {
             } else {
                 var migrator;
                 try {
-                    migrator = new SchemaMigrator(self, currentSchemaInfo, newSchemaInfo);
+                    migrator = new SchemaMigrator(self, req, currentSchemaInfo, newSchemaInfo);
                 }
                 catch (error) {
                     throw new dbu.HTTPError({

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -1,10 +1,11 @@
 "use strict";
 
+require('core-js/shim');
+
 var dbu = require('./dbutils');
 var P = require('bluebird');
 var util = require('util');
 
-var hash = dbu.makeSchemaHash;
 
 /**
  * Base migration handler for unsupported schema
@@ -16,7 +17,7 @@ function Unsupported(attr, current, proposed) {
 }
 
 Unsupported.prototype.validate = function() {
-    if (hash(this.current) !== hash(this.proposed)) {
+    if (dbu.makeSchemaHash(this.current) !== dbu.makeSchemaHash(this.proposed)) {
         throw new Error(this.attr + ' attribute migrations are unsupported');
     }
 };
@@ -28,7 +29,7 @@ Unsupported.prototype.migrate = function() {
 /**
  * Table name handler
  */
-function Table(db, current, proposed) {
+function Table(parent, current, proposed) {
     Unsupported.call(this, 'table', current, proposed);
 }
 
@@ -37,7 +38,7 @@ util.inherits(Table, Unsupported);
 /**
  * options object migration handler
  */
-function Options(db, current, proposed) {
+function Options(parent, current, proposed) {
     Unsupported.call(this, 'options', current, proposed);
 }
 
@@ -46,16 +47,64 @@ util.inherits(Options, Unsupported);
 /**
  * attributes object migration handler
  */
-function Attributes(db, current, proposed) {
-    Unsupported.call(this, 'attributes', current, proposed);
+function Attributes(parent, current, proposed) {
+    this.client = parent.db.client;
+    this.log = parent.db.log;
+    this.table = dbu.cassID(parent.req.keyspace)+'.'+dbu.cassID(parent.req.columnfamily);
+    this.consistency = parent.req.consistency;
+    this.current = current;
+    this.proposed = proposed;
+
+    var currSet = new Set(Object.keys(this.current));
+    var propSet = new Set(Object.keys(this.proposed));
+
+    this.addColumns = Array.from(propSet).filter(function(x) { return !currSet.has(x); });
+    this.delColumns = Array.from(currSet).filter(function(x) { return !propSet.has(x); });
 }
 
-util.inherits(Attributes, Unsupported);
+// The only constraint here: that any attribute being dropped must not
+// be part of an existing index, something which the standard schema
+// validation already covers.
+Attributes.prototype.validate = function() {
+    return;
+};
+
+Attributes.prototype._alterTable = function() {
+    return 'ALTER TABLE '+this.table;
+};
+
+Attributes.prototype._colType = function(col) {
+    return dbu.schemaTypeToCQLType(this.proposed[col]);
+};
+
+Attributes.prototype._alterTableAdd = function(col) {
+    return this._alterTable()+' ADD '+dbu.cassID(col)+' '+this._colType(col);
+};
+
+Attributes.prototype._alterTableDrop = function(col) {
+    return this._alterTable()+' DROP '+dbu.cassID(col);
+};
+
+Attributes.prototype.migrate = function() {
+    var self = this;
+    return P.each(self.addColumns, function(col) {
+        self.log('warn/schemaMigration/attributes', 'adding ' + col);
+        var cql = self._alterTableAdd(col);
+        return self.client.execute_p(cql, [], { consistency: self.consistency });
+    })
+    .then(function() {
+        return P.each(self.delColumns, function(col) {
+            self.log('warn/schemaMigration/attributes', 'dropping ' + col);
+            var cql = self._alterTableDrop(col);
+            return self.client.execute_p(cql, [], { consistency: self.consistency });
+        });
+    });
+};
 
 /**
  * Index definition migrations
  */
-function Index(db, current, proposed) {
+function Index(parent, current, proposed) {
     Unsupported.call(this, 'index', current, proposed);
 }
 
@@ -64,7 +113,7 @@ util.inherits(Index, Unsupported);
 /**
  * Secondary index definition migrations
  */
-function SecondaryIndexes(db, current, proposed) {
+function SecondaryIndexes(parent, current, proposed) {
     Unsupported.call(this, 'secondaryIndexes', current, proposed);
 }
 
@@ -73,8 +122,8 @@ util.inherits(SecondaryIndexes, Unsupported);
 /**
  * Revision retention policy definiation migrations
  */
-function RevisionRetentionPolicy(db, current, proposed) {
-    this.db = db;
+function RevisionRetentionPolicy(parent, current, proposed) {
+    this.db = parent.db;
     this.current = current;
     this.proposed = proposed;
 }
@@ -94,8 +143,8 @@ RevisionRetentionPolicy.prototype.migrate = function() {
 /**
  * Version handling
  */
-function Version(db, current, proposed) {
-    this.db = db;
+function Version(parent, current, proposed) {
+    this.db = parent.db;
     this.current = current;
     this.proposed = proposed;
 }
@@ -137,14 +186,15 @@ var migrationHandlers = {
  * @param  {object} schemaTo; proposed schema info object.
  * @throws  {Error} if the proposed migration fails to validate
  */
-function SchemaMigrator(db, current, proposed) {
+function SchemaMigrator(db, req, current, proposed) {
     this.db = db;
+    this.req = req;
     this.current = current;
     this.proposed = proposed;
 
     var self = this;
     this.migrators = Object.keys(migrationHandlers).map(function(key) {
-        return new migrationHandlers[key](db, self.current[key], self.proposed[key]);
+        return new migrationHandlers[key](self, current[key], proposed[key]);
     });
 
     this._validate();

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -1,7 +1,5 @@
 "use strict";
 
-require('core-js/shim');
-
 var dbu = require('./dbutils');
 var P = require('bluebird');
 var util = require('util');
@@ -29,7 +27,7 @@ Unsupported.prototype.migrate = function() {
 /**
  * Table name handler
  */
-function Table(parent, current, proposed) {
+function Table(parentMigrator, current, proposed) {
     Unsupported.call(this, 'table', current, proposed);
 }
 
@@ -38,7 +36,7 @@ util.inherits(Table, Unsupported);
 /**
  * options object migration handler
  */
-function Options(parent, current, proposed) {
+function Options(parentMigrator, current, proposed) {
     Unsupported.call(this, 'options', current, proposed);
 }
 
@@ -47,11 +45,11 @@ util.inherits(Options, Unsupported);
 /**
  * attributes object migration handler
  */
-function Attributes(parent, current, proposed) {
-    this.client = parent.db.client;
-    this.log = parent.db.log;
-    this.table = dbu.cassID(parent.req.keyspace)+'.'+dbu.cassID(parent.req.columnfamily);
-    this.consistency = parent.req.consistency;
+function Attributes(parentMigrator, current, proposed) {
+    this.client = parentMigrator.db.client;
+    this.log = parentMigrator.db.log;
+    this.table = dbu.cassID(parentMigrator.req.keyspace)+'.'+dbu.cassID(parentMigrator.req.columnfamily);
+    this.consistency = parentMigrator.req.consistency;
     this.current = current;
     this.proposed = proposed;
 
@@ -104,7 +102,7 @@ Attributes.prototype.migrate = function() {
 /**
  * Index definition migrations
  */
-function Index(parent, current, proposed) {
+function Index(parentMigrator, current, proposed) {
     Unsupported.call(this, 'index', current, proposed);
 }
 
@@ -113,7 +111,7 @@ util.inherits(Index, Unsupported);
 /**
  * Secondary index definition migrations
  */
-function SecondaryIndexes(parent, current, proposed) {
+function SecondaryIndexes(parentMigrator, current, proposed) {
     Unsupported.call(this, 'secondaryIndexes', current, proposed);
 }
 
@@ -122,8 +120,8 @@ util.inherits(SecondaryIndexes, Unsupported);
 /**
  * Revision retention policy definiation migrations
  */
-function RevisionRetentionPolicy(parent, current, proposed) {
-    this.db = parent.db;
+function RevisionRetentionPolicy(parentMigrator, current, proposed) {
+    this.db = parentMigrator.db;
     this.current = current;
     this.proposed = proposed;
 }
@@ -143,8 +141,8 @@ RevisionRetentionPolicy.prototype.migrate = function() {
 /**
  * Version handling
  */
-function Version(parent, current, proposed) {
-    this.db = parent.db;
+function Version(parentMigrator, current, proposed) {
+    this.db = parentMigrator.db;
     this.current = current;
     this.proposed = proposed;
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "async": "0.x.x",
     "bluebird": "~2.3.10",
-    "core-js": "^0.5.4",
     "cassandra-driver": "~2.0.0",
     "extend": "^2.0.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
@@ -20,7 +19,8 @@
     "coverage": "istanbul cover _mocha -- -R spec",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
-  "devDependencies": {
+    "devDependencies": {
+    "core-js": "^0.5.4",
     "coveralls": "2.11.2",
     "routeswitch": "~0.6.3",
     "istanbul": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "async": "0.x.x",
     "bluebird": "~2.3.10",
+    "core-js": "^0.5.4",
     "cassandra-driver": "~2.0.0",
     "extend": "^2.0.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",

--- a/test/test_router.js
+++ b/test/test_router.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require('core-js/shim');
+
 /*
 *  test router to exercise all tests uning the restbase-cassandra handler
 */


### PR DESCRIPTION
Adds an implementation of schemaMigration.Attributes (which previously
inherited Unsupported).  Iteratatively adds and/or removes the delta
attributes of two schemas.

Bug: T97073