### PR TITLE
back-end versioning

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -9,7 +9,6 @@ var cassID = dbu.cassID;
 var revPolicy = require('./revisionPolicy');
 var SchemaMigrator = require('./schemaMigration');
 var secIndexes = require('./secondaryIndexes');
-var validator = require('restbase-mod-table-spec').validator;
 
 
 function DB (client, options) {
@@ -195,7 +194,7 @@ DB.prototype._resolveStorageGroup = function (domain) {
 
 
 // Info table schema
-DB.prototype.infoSchema = validator.validateAndNormalizeSchema({
+DB.prototype.infoSchema = dbu.validateAndNormalizeSchema({
     table: 'meta',
     attributes: {
         key: 'string',
@@ -667,6 +666,26 @@ DB.prototype._delete = function (req) {
     return this._put(req);
 };
 
+/**
+ * Evaluate, and if neccessary, perform a migration from one back-end version
+ * to another.
+ *
+ * @param  {object} req;  the current request object
+ * @param  {object} from; schema info object representing current state
+ * @param  {object} to;   schema info object representing proposed state
+ * @return {boolean} a promise that resolves to true if a back-end migration
+ *         occurred.
+ */
+DB.prototype._migrateBackend = function(req, from, to) {
+    // Perform a backend migration, as-needed.
+    switch(from._backend_version) {
+    case 0:
+        return this._dropDomainIndex(req);
+    default:
+        return P.resolve();
+    }
+};
+
 DB.prototype.createTable = function (domain, query) {
     var self = this;
     if (!query.table) {
@@ -682,42 +701,58 @@ DB.prototype.createTable = function (domain, query) {
         var currentSchemaInfo = req.schema;
 
         // Validate and normalize the schema
-        var newSchema = validator.validateAndNormalizeSchema(req.query);
+        var newSchema = dbu.validateAndNormalizeSchema(req.query);
         var newSchemaInfo = dbu.makeSchemaInfo(newSchema);
 
         if (currentSchemaInfo) {
             // Table already exists
-            // Use JSON.stringify to avoid object equality on functions
-            if (currentSchemaInfo.hash === newSchemaInfo.hash) {
-                if (!currentSchemaInfo._domainIndexDropped) {
-                    // Hacky flag to avoid dropping index on each request.
-                    // TODO: Properly keep track of internal schema versions!
-                    currentSchemaInfo._domainIndexDropped= true;
-                    // Asynchronously drop native secondary index on _domain column
-                    self._dropDomainIndex(req);
+            var migrationPromise = P.resolve();
+            var emptyPromise = migrationPromise;
+            // First carry out any back-end migration (if needed).
+            if (currentSchemaInfo._backend_version !== newSchemaInfo._backend_version) {
+                // A downgrade (unsupported)!
+                if (newSchemaInfo._backend_version < currentSchemaInfo._backend_version) {
+                    throw new dbu.HTTPError({
+                        status: 400,
+                        body: {
+                            type: 'bad_request',
+                            title: 'Unable to downgrade storage backend to version '+newSchemaInfo._backend_version,
+                            keyspace: req.keyspace,
+                            schema: newSchema
+                        }
+                    });
                 }
+                
+                migrationPromise = self._migrateBackend(req, currentSchemaInfo, newSchemaInfo);
+            }
 
-                // all good & nothing to do.
-                return {
-                    status: 201
-                };
-            } else {
+            // Next carry out any table schema migration (if needed).
+            if (currentSchemaInfo.hash !== newSchemaInfo.hash) {
                 var migrator;
                 try {
-                    migrator = new SchemaMigrator(self, req, currentSchemaInfo, newSchemaInfo);
+                    migrator = new SchemaMigrator(
+                        self,
+                        req,
+                        currentSchemaInfo,
+                        newSchemaInfo);
                 }
                 catch (error) {
                     throw new dbu.HTTPError({
                         status: 400,
                         body: {
                             type: 'bad_request',
-                            title: 'The table already exists, and its schema cannot be upgraded to the requested schema ('+error+').',
+                            title: 'The table already exists, and it cannot be upgraded to the requested schema ('+error+').',
                             keyspace: req.keyspace,
                             schema: newSchema
                         }
                     });
                 }
-                return migrator.migrate()
+                migrationPromise = migrationPromise.then(migrator.migrate.bind(migrator));
+            }
+
+            // Finally, if there are any migrations, apply them and persist.
+            if (migrationPromise !== emptyPromise) {
+                return migrationPromise
                 .then(function() {
                     var putReq = req.extend({
                         columnfamily: 'meta',
@@ -734,12 +769,17 @@ DB.prototype.createTable = function (domain, query) {
                         // Force a cache update on subsequent requests
                         self._initSchemaCache();
                         return { status: 201 };
+                    })
+                    .catch(function(error) {
+                        self.log('error/cassandra/table_update', error);
+                        throw error;
                     });
-                })
-                .catch(function(error) {
-                    self.log('error/cassandra/table_update', error);
-                    throw error;
                 });
+            }
+            else {
+                return {
+                    status: 201
+                };
             }
         }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -708,6 +708,18 @@ DB.prototype.createTable = function (domain, query) {
             // Table already exists
             var migrationPromise = P.resolve();
             var emptyPromise = migrationPromise;
+
+            // The _backend_version attribute is excluded from the schema hash
+            // calculation so that we can evaluate these different classes of
+            // change (_backend_version versus table schema) separately.  If
+            // backend versions differ, a backend migration will need to be
+            // performed first.  Afterward, if and only if there has been a
+            // change to the schema (that is if the hashes do not match), will
+            // a schema migration occur. These schema changes must also include
+            // a monotonically increasing version number.  Finally, if either
+            // (or both) of a backend or table schema migration occur, the new
+            // JSON blob will be persisted.
+
             // First carry out any back-end migration (if needed).
             if (currentSchemaInfo._backend_version !== newSchemaInfo._backend_version) {
                 // A downgrade (unsupported)!

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -1,10 +1,14 @@
 "use strict";
+
+require('core-js/shim');
+
 var crypto = require('crypto');
 var extend = require('extend');
 var cass = require('cassandra-driver');
 var util = require('util');
 var P = require('bluebird');
 var stringify = require('json-stable-stringify');
+var validator = require('restbase-mod-table-spec').validator;
 
 /*
  * Various static database utility methods
@@ -109,7 +113,10 @@ dbu.makeValidKey = function makeValidKey (key, length) {
  * @return {string} the schema serialized to string
  */
 dbu.makeSchemaHash = function makeSchemaHash(schema) {
-    return stringify(schema);
+    var clone = Object.assign({}, schema);
+    // eliminate _backend_version from hash comparisons
+    delete clone._backend_version;
+    return stringify(clone);
 };
 
 /**
@@ -202,6 +209,21 @@ dbu.eachRow = function eachRow(client, query, params, options, handler) {
 /*
  * # Section 2: Schema validation, normalization and -handling
  */
+
+dbu.DEFAULT_BACKEND_VERSION = 0;
+dbu.CURRENT_BACKEND_VERSION = 1;
+
+/**
+ * Wrapper for validator#validateAndNormalizeSchema (shipped in
+ * restbase-m-t-spec). Ensures the presence of the private,
+ * implementation-specific _backend_version schema attribute.
+ */
+dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
+    if (!schema._backend_version) {
+        schema._backend_version = dbu.CURRENT_BACKEND_VERSION;
+    }
+    return validator.validateAndNormalizeSchema(schema);
+};
 
 // Extract the index keys from a table schema
 dbu.indexKeys = function indexKeys (index) {
@@ -476,6 +498,10 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema, isMetaCF) {
 
     if (!psi.revisionRetentionPolicy) {
         psi.revisionRetentionPolicy = { type: 'all' };
+    }
+
+    if (!psi._backend_version) {
+        psi._backend_version = dbu.DEFAULT_BACKEND_VERSION;
     }
 
     // define a 'hash' string representation for the schema for quick schema

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -114,7 +114,7 @@ dbu.makeValidKey = function makeValidKey (key, length) {
  */
 dbu.makeSchemaHash = function makeSchemaHash(schema) {
     var clone = Object.assign({}, schema);
-    // eliminate _backend_version from hash comparisons
+    // eliminate _backend_version from hash comparisons (see: DB#createTable)
     delete clone._backend_version;
     return stringify(clone);
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "coveralls": "2.11.2",
+    "core-js": "^0.5.4",
     "istanbul": "0.3.5",
     "mocha": "x.x.x",
     "mocha-jshint": "0.0.9",

--- a/test/functional/backend_migrations.js
+++ b/test/functional/backend_migrations.js
@@ -1,0 +1,71 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var assert = require('assert');
+var dbu = require('../../lib/dbutils');
+var fs = require('fs');
+var makeClient = require('../../lib/index');
+var yaml = require('js-yaml');
+
+var testTable0 = {
+    table: 'backendVersioning',
+    options: { durability: 'low' },
+    attributes: {
+        title: 'string',
+        rev: 'int',
+        tid: 'timeuuid',
+        comment: 'string',
+        author: 'string'
+    },
+    index: [
+        { attribute: 'title', type: 'hash' },
+        { attribute: 'rev', type: 'range', order: 'desc' },
+        { attribute: 'tid', type: 'range', order: 'desc' }
+    ],
+    secondaryIndexes: {
+        by_rev : [
+            { attribute: 'rev', type: 'hash' },
+            { attribute: 'tid', type: 'range', order: 'desc' },
+            { attribute: 'title', type: 'range', order: 'asc' },
+            { attribute: 'comment', type: 'proj' }
+        ]
+    }
+};
+
+describe('Backend migration', function() {
+    var db;
+    before(function() {
+        return makeClient({
+            log: function(level, info) {
+                if (!/^info|warn|verbose|debug|trace/.test(level)) {
+                    console.log(level, info);
+                }
+            },
+            conf: yaml.safeLoad(fs.readFileSync(__dirname + '/../utils/test_client.conf.yaml'))
+        })
+        .then(function(newDb) {
+            db = newDb;
+        })
+        .then(function() {
+            return db.createTable('restbase.cassandra.test.local', testTable0);
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 201);
+        });
+    });
+    after(function() {
+        db.dropTable('restbase.cassandra.test.local', testTable0.table);
+    });
+
+    it('persists a backend version', function() {
+        return db.getTableSchema('restbase.cassandra.test.local', testTable0.table)
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.schema.table, testTable0.table);
+            assert.deepEqual(response.schema._backend_version, dbu.CURRENT_BACKEND_VERSION);
+        });
+    });
+});

--- a/test/unit/dbutils.js
+++ b/test/unit/dbutils.js
@@ -5,7 +5,6 @@
 
 var assert = require('assert');
 var dbu = require('../../lib/dbutils');
-var validator = require('restbase-mod-table-spec').validator;
 
 var testTable0a = {
     domain: 'restbase.cassandra.test.local',
@@ -74,7 +73,7 @@ describe('DB utilities', function() {
             keyspace: 'keyspace',
             columnfamily: 'columnfamily',
             domain: 'en.wikipedia.org',
-            schema: dbu.makeSchemaInfo(validator.validateAndNormalizeSchema(testTable0a)),
+            schema: dbu.makeSchemaInfo(dbu.validateAndNormalizeSchema(testTable0a)),
             query: {},
         };
         var statement = dbu.buildGetQuery(req, { withTTLs: true });
@@ -110,7 +109,7 @@ describe('DB utilities', function() {
             keyspace: 'keyspace',
             columnfamily: 'columnfamily',
             domain: 'en.wikipedia.org',
-            schema: dbu.makeSchemaInfo(validator.validateAndNormalizeSchema(testTable0a)),
+            schema: dbu.makeSchemaInfo(dbu.validateAndNormalizeSchema(testTable0a)),
             query: {},
         };
         var cql = dbu.buildGetQuery(req, { limit: 42 }).cql;
@@ -139,7 +138,7 @@ describe('Schema validation', function() {
         policies.forEach(function(policy) {
             var schema = { revisionRetentionPolicy: policy };
             assert.throws(
-                validator.validateAndNormalizeSchema.bind(null, schema),
+                dbu.validateAndNormalizeSchema.bind(null, schema),
                 Error,
                 'Validated an invalid schema');
         });
@@ -147,7 +146,7 @@ describe('Schema validation', function() {
 
     it('defaults revision retention policy to \'all\'', function() {
         var schemaInfo = dbu.makeSchemaInfo(
-                validator.validateAndNormalizeSchema({
+                dbu.validateAndNormalizeSchema({
                         attributes: {
                             foo: 'int'
                         },


### PR DESCRIPTION
Given the case where *both* a backend version migration, and a table
storage schema migration are needed, it stands to reason that the latter
might depend on the former.  Because of this, the two cases need to be
treated separately, and table schema migration must occur after any backend
migration has completed.

This changeset introduces a `_backend_version` attribute to the schema blob
but does not consider it when generating the hash.  DB#_createTable
first evaluates `_backend_version`, performs a back-end migration if
necessary, then compares hashes and performs a table schema migration if
necessary.  Finally, if any changes were made, the persisted schema blob
is updated.

Bug: T97845