### PR TITLE
Be robust against schema update races

### DIFF
--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -91,7 +91,15 @@ Attributes.prototype.migrate = function() {
             column: col,
         });
         var cql = self._alterTableAdd(col);
-        return self.client.execute_p(cql, [], { consistency: self.consistency });
+        return self.client.execute_p(cql, [], { consistency: self.consistency })
+        .catch(function(e) {
+            if (!new RegExp('Invalid column name ' + col
+                        + ' because it conflicts with an existing column').test(e.message)) {
+                throw(e);
+            }
+            // Else: Ignore the error if the column already exists.
+        });
+
     })
     .then(function() {
         return P.each(self.delColumns, function(col) {
@@ -100,7 +108,13 @@ Attributes.prototype.migrate = function() {
                 column: col,
             });
             var cql = self._alterTableDrop(col);
-            return self.client.execute_p(cql, [], { consistency: self.consistency });
+            return self.client.execute_p(cql, [], { consistency: self.consistency })
+            .catch(function(e) {
+                if (e.message !== 'Column ' + col + ' was not found in table data') {
+                    throw(e);
+                }
+                // Else: Ignore the error if the column was already removed.
+            });
         });
     });
 };


### PR DESCRIPTION
Don't fail if columns to add already exist, or columns to remove don't exist
any more. This make sure that racing workers eventually make progress with
schema updates.