### PR TITLE
move schema validation tests to dbutils

### DIFF
--- a/test/dbutils.js
+++ b/test/dbutils.js
@@ -67,3 +67,44 @@ describe('DB utilities', function() {
             dbu.makeSchemaHash(testTable0b));
     });
 });
+
+describe('Schema validation', function() {
+    it('rejects invalid revision retention policy schema', function() {
+        var policies = [
+            {
+                type: 'bogus'    // Invalid
+            },
+            {
+                type: 'latest',
+                count: 1,
+                grace_ttl: 5     // Invalid
+            },
+            {
+                type: 'latest',
+                count: 0,        // Invalid
+                grace_ttl: 86400
+            }
+        ];
+
+        policies.forEach(function(policy) {
+            var schema = { revisionRetentionPolicy: policy };
+            assert.throws(
+                dbu.validateAndNormalizeRevPolicy.bind(null, schema),
+                Error,
+                'Validated an invalid schema');
+        });
+    });
+
+    it('defaults revision retention policy to \'all\'', function() {
+        var schemaInfo = dbu.makeSchemaInfo(
+                dbu.validateAndNormalizeSchema({
+                        attributes: {
+                            foo: 'int'
+                        },
+                        index: [
+                            { attribute: 'foo', type: 'hash' }
+                        ]
+                    }));
+        assert.deepEqual('all', schemaInfo.revisionRetentionPolicy.type);
+    });
+});

--- a/test/revision_policies.js
+++ b/test/revision_policies.js
@@ -131,45 +131,5 @@ describe('MVCC revision policies', function() {
             assert.deepEqual(response.items.length, 2);
         });
     });
-
-    // XXX: Consider moving to a file of dbutils unit tests?
-    it('rejects invalid revision retention policy schema', function() {
-        var policies = [
-            {
-                type: 'bogus'    // Invalid
-            },
-            {
-                type: 'latest',
-                count: 1,
-                grace_ttl: 5     // Invalid
-            },
-            {
-                type: 'latest',
-                count: 0,        // Invalid
-                grace_ttl: 86400
-            }
-        ];
-
-        policies.forEach(function(policy) {
-            var schema = { revisionRetentionPolicy: policy };
-            assert.throws(
-                dbu.validateAndNormalizeRevPolicy.bind(null, schema),
-                Error,
-                'Validated an invalid schema');
-        });
-    });
-
-    it('defaults to retention \'all\'', function() {
-        var schemaInfo = dbu.makeSchemaInfo(
-                dbu.validateAndNormalizeSchema({
-                        attributes: {
-                            foo: 'int'
-                        },
-                        index: [
-                            { attribute: 'foo', type: 'hash' }
-                        ]
-                    }));
-        assert.deepEqual('all', schemaInfo.revisionRetentionPolicy.type);
-    });
 });
 


### PR DESCRIPTION
While being related to revision retention policy, the affected tests
test validation of the schema, and are thus better treated as unit
tests in `test/dbutils.js`.

This is also necessary to break the tests dependency on dbutils,
(relevant to T103406).

Bug: T103406