### PR TITLE
Normalise asynchronous updates and release v0.7.0

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -75,11 +75,11 @@ DB.prototype._makeInternalRequest = function (domain, table, query, consistency)
             columnfamily: 'meta',
             schema: this.infoSchemaInfo
         });
-        return this._get(schemaReq)
+        return this._getRaw(schemaReq)
         .then(function(res) {
             if (res.items.length) {
                 // Need to parse the JSON manually here as we are using the
-                // internal _get(), which doesn't apply transforms.
+                // internal _getRaw(), which doesn't apply transforms.
                 var schema = JSON.parse(res.items[0].value);
                 self.keyspaceNameCache[cacheKey] = req.keyspace;
                 self.schemaCache[cacheKey] = req.schema = dbu.makeSchemaInfo(schema);
@@ -214,7 +214,7 @@ DB.prototype.get = function (domain, query) {
     var self = this;
     return this._makeInternalRequest(domain, query.table, query)
     .then(function(req) {
-        return self._get(req)
+        return self._getRaw(req)
         .then(function(res) {
             // Apply value conversions
             res.items = dbu.convertRows(res.items, req.schema);
@@ -223,7 +223,7 @@ DB.prototype.get = function (domain, query) {
     });
 };
 
-DB.prototype._get = function (req) {
+DB.prototype._getRaw = function (req) {
     var self = this;
 
     if (!req.schema) {
@@ -586,7 +586,7 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
     // Query for a window that includes 1 newer record (if any exists), and up
     // to 'limit' later records.  Run the list of update handlers across each
     // matching row, in descending order.
-    return self._get(newerRebuildRequest)
+    return self._getRaw(newerRebuildRequest)
     .then(function(res) {    // Query for one record previous
         return P.each(res.items.reverse(), handler.handleRow.bind(handler));
     })
@@ -903,7 +903,7 @@ DB.prototype.getTableSchema = function(domain, table) {
         columnfamily: 'meta',
         schema: this.infoSchemaInfo
     });
-    return this._get(req)
+    return this._getRaw(req)
     .then(function(response) {
         if (!response.items.length) {
             throw new dbu.HTTPError({

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -627,18 +627,20 @@ dbu.convertRows = function convertRows (rows, schema) {
 };
 
 /**
- * Converts an internal request's query attributes to native
+ * Deep-clones and converts an internal request's query attributes to native
  * Cassandra representations
  *
  * @param {InternalRequest} internalReq the request whose attributes to convert
- * @param {Object} schema optionally, use this schema instead of internalReq.schema
- * @return {InternalRequest} the same request passed in, with converted values
+ * @return {InternalRequest} the clone of the request passed in, with converted values
  */
-dbu.convertWriteReqQueryAttrs = function(internalReq, schema) {
-    var conversions = (schema || internalReq.schema || {}).conversions;
-    var attrs = internalReq.query.attributes;
+dbu.makeConvertedRequest = function(internalReq) {
+    var conversions = (internalReq.schema || {}).conversions;
+    var clonedReq = internalReq.extend({
+        query: extend(true, {}, internalReq.query)
+    });
+    var attrs = clonedReq.query.attributes;
     if(!conversions || !attrs) {
-        return internalReq;
+        return clonedReq;
     }
     Object.keys(attrs).forEach(function(key) {
         var conv = conversions[key];
@@ -646,7 +648,7 @@ dbu.convertWriteReqQueryAttrs = function(internalReq, schema) {
             attrs[key] = conv.write(attrs[key]);
         }
     });
-    return internalReq;
+    return clonedReq;
 };
 
 /*

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -670,6 +670,14 @@ dbu.buildCondition = function buildCondition (predicates, schema, convertFunc) {
         }
     };
 
+    // make sure we have got a predicate object
+    if(!predicates || predicates.constructor !== Object) {
+        return {
+            cql: predicates || '',
+            params: []
+        };
+    }
+
     var params = [];
     var conjunctions = [];
     Object.keys(predicates).forEach(function(predKey) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -492,10 +492,6 @@ dbu.conversions = {
     uuid: { read: toString() }
 };
 
-dbu.noConvert = function(key, val) {
-    return val;
-};
-
 /*
  * Derive additional schema info from the public schema
  */
@@ -659,18 +655,18 @@ dbu.makeRawRequest = function(internalReq) {
  * CQL building for conditional requests in general.
  * @param {object} predicates, the 'attributes' object in queries.
  * @param {object} schema, the schema info for the logical table.
- * @param {Function} convertFunc the conversion function to use
+ * @param {Boolean} noConvert if true, no attribute value conversion will take place
  * @return {object} queryInfo object with cql and params attributes
  */
-dbu.buildCondition = function buildCondition (predicates, schema, convertFunc) {
-    convertFunc = convertFunc || function(key, val) {
+dbu.buildCondition = function buildCondition (predicates, schema, noConvert) {
+    function convert(key, val) {
         var convObj = schema.conversions[key];
-        if (convObj && convObj.write) {
+        if (!noConvert && convObj && convObj.write) {
             return convObj.write(val);
         } else {
             return val;
         }
-    };
+    }
 
     // make sure we have got a predicate object
     if(!predicates || predicates.constructor !== Object) {
@@ -692,7 +688,7 @@ dbu.buildCondition = function buildCondition (predicates, schema, convertFunc) {
         } else if (predObj === null || predObj.constructor !== Object) {
             // Default to equality
             cql += ' = ?';
-            params.push(convertFunc(predKey, predObj));
+            params.push(convert(predKey, predObj));
         } else {
             var predKeys = Object.keys(predObj);
             if (predKeys.length === 1) {
@@ -702,34 +698,34 @@ dbu.buildCondition = function buildCondition (predicates, schema, convertFunc) {
                 switch (predOp.toLowerCase()) {
                 case 'eq':
                     cql += ' = ?';
-                    params.push(convertFunc(predKey, predArg));
+                    params.push(convert(predKey, predArg));
                     break;
                 case 'lt':
                     cql += ' < ?';
-                    params.push(convertFunc(predKey, predArg));
+                    params.push(convert(predKey, predArg));
                     break;
                 case 'gt':
                     cql += ' > ?';
-                    params.push(convertFunc(predKey, predArg));
+                    params.push(convert(predKey, predArg));
                     break;
                 case 'le':
                     cql += ' <= ?';
-                    params.push(convertFunc(predKey, predArg));
+                    params.push(convert(predKey, predArg));
                     break;
                 case 'ge':
                     cql += ' >= ?';
-                    params.push(convertFunc(predKey, predArg));
+                    params.push(convert(predKey, predArg));
                     break;
                 case 'neq':
                 case 'ne':
                     cql += ' != ?';
-                    params.push(convertFunc(predKey, predArg));
+                    params.push(convert(predKey, predArg));
                     break;
                 case 'between':
                         cql += ' >= ?' + ' AND ';
-                        params.push(convertFunc(predKey, predArg[0]));
+                        params.push(convert(predKey, predArg[0]));
                         cql += dbu.cassID(predKey) + ' <= ?';
-                        params.push(convertFunc(predKey, predArg[1]));
+                        params.push(convert(predKey, predArg[1]));
                         break;
                 default: throw new Error ('Operator ' + predOp + ' not supported!');
                 }
@@ -749,10 +745,10 @@ dbu.buildCondition = function buildCondition (predicates, schema, convertFunc) {
 /**
  * CQL building for PUT queries
  * @param {InternalRequest} req
- * @param {Function} convertFunc the conversion function to use
+ * @param {Boolean} noConvert if true, no attribute value conversion will take place
  * @return {object} queryInfo object with cql and params attributes
  */
-dbu.buildPutQuery = function(req, convertFunc) {
+dbu.buildPutQuery = function(req, noConvert) {
 
     //table = schema.table;
 
@@ -768,13 +764,6 @@ dbu.buildPutQuery = function(req, convertFunc) {
         attributes._domain = req.domain;
     }
     var conversions = schema.conversions || {};
-    convertFunc = convertFunc || function(attr_key, attr_val) {
-        var conversionObj = conversions[attr_key];
-        if (conversionObj && conversionObj.write) {
-            return conversionObj.write(attr_val);
-        }
-        return attr_val;
-    };
 
     // XXX: should we require non-null secondary index entries too?
     var indexKVMap = {};
@@ -797,7 +786,10 @@ dbu.buildPutQuery = function(req, convertFunc) {
             if (!schema.iKeyMap[key]) {
                 nonIndexKeys.push(key);
                 // Convert the parameter value
-                val = convertFunc(key, val);
+                var conversionObj = conversions[key];
+                if (!noConvert && conversionObj && conversionObj.write) {
+                    val = conversionObj.write(val);
+                }
                 if (val !== null && schema.staticKeyMap && !schema.staticKeyMap[key]) {
                     haveNonIndexNonNullValue = true;
                 }
@@ -837,7 +829,7 @@ dbu.buildPutQuery = function(req, convertFunc) {
         query.if = query.if.trim().split(/\s+/).join(' ').toLowerCase();
     }
 
-    var condRes = dbu.buildCondition(indexKVMap, schema, convertFunc);
+    var condRes = dbu.buildCondition(indexKVMap, schema, noConvert);
 
     var cond = '';
     if (!haveNonIndexNonNullValue || query.if === 'not exists') {
@@ -855,7 +847,7 @@ dbu.buildPutQuery = function(req, convertFunc) {
         var condParamKeys = [];
         if (query.if) {
             cond = ' if ';
-            condResult = dbu.buildCondition(query.if, schema, convertFunc);
+            condResult = dbu.buildCondition(query.if, schema, noConvert);
             cond += condResult.cql;
             condParams = condResult.params;
             condParamKeys = condResult.keys;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -627,13 +627,14 @@ dbu.convertRows = function convertRows (rows, schema) {
  * Cassandra representations
  *
  * @param {InternalRequest} internalReq the request whose attributes to convert
+ * @param {Object} extendFields any other fields to use when extending the request object; optional
  * @return {InternalRequest} the clone of the request passed in, with converted values
  */
-dbu.makeRawRequest = function(internalReq) {
+dbu.makeRawRequest = function(internalReq, extendFields) {
     var conversions = (internalReq.schema || {}).conversions;
-    var clonedReq = internalReq.extend({
-        query: extend(true, {}, internalReq.query)
-    });
+    extendFields = extendFields || {};
+    extendFields.query = extend(true, {}, internalReq.query);
+    var clonedReq = internalReq.extend(extendFields);
     var attrs = clonedReq.query.attributes;
     if(!conversions || !attrs) {
         return clonedReq;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -633,7 +633,7 @@ dbu.convertRows = function convertRows (rows, schema) {
  * @param {InternalRequest} internalReq the request whose attributes to convert
  * @return {InternalRequest} the clone of the request passed in, with converted values
  */
-dbu.makeConvertedRequest = function(internalReq) {
+dbu.makeRawRequest = function(internalReq) {
     var conversions = (internalReq.schema || {}).conversions;
     var clonedReq = internalReq.extend({
         query: extend(true, {}, internalReq.query)

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -492,6 +492,10 @@ dbu.conversions = {
     uuid: { read: toString() }
 };
 
+dbu.noConvert = function(key, val) {
+    return val;
+};
+
 /*
  * Derive additional schema info from the public schema
  */
@@ -622,6 +626,29 @@ dbu.convertRows = function convertRows (rows, schema) {
     return newRows;
 };
 
+/**
+ * Converts an internal request's query attributes to native
+ * Cassandra representations
+ *
+ * @param {InternalRequest} internalReq the request whose attributes to convert
+ * @param {Object} schema optionally, use this schema instead of internalReq.schema
+ * @return {InternalRequest} the same request passed in, with converted values
+ */
+dbu.convertWriteReqQueryAttrs = function(internalReq, schema) {
+    var conversions = (schema || internalReq.schema || {}).conversions;
+    var attrs = internalReq.query.attributes;
+    if(!conversions || !attrs) {
+        return internalReq;
+    }
+    Object.keys(attrs).forEach(function(key) {
+        var conv = conversions[key];
+        if(conv && conv.write) {
+            attrs[key] = conv.write(attrs[key]);
+        }
+    });
+    return internalReq;
+};
+
 /*
  * # Section 3: CQL query generation
  */
@@ -630,17 +657,18 @@ dbu.convertRows = function convertRows (rows, schema) {
  * CQL building for conditional requests in general.
  * @param {object} predicates, the 'attributes' object in queries.
  * @param {object} schema, the schema info for the logical table.
+ * @param {Function} convertFunc the conversion function to use
  * @return {object} queryInfo object with cql and params attributes
  */
-dbu.buildCondition = function buildCondition (predicates, schema) {
-    function convert(key, val) {
+dbu.buildCondition = function buildCondition (predicates, schema, convertFunc) {
+    convertFunc = convertFunc || function(key, val) {
         var convObj = schema.conversions[key];
         if (convObj && convObj.write) {
             return convObj.write(val);
         } else {
             return val;
         }
-    }
+    };
 
     var params = [];
     var conjunctions = [];
@@ -654,7 +682,7 @@ dbu.buildCondition = function buildCondition (predicates, schema) {
         } else if (predObj === null || predObj.constructor !== Object) {
             // Default to equality
             cql += ' = ?';
-            params.push(convert(predKey, predObj));
+            params.push(convertFunc(predKey, predObj));
         } else {
             var predKeys = Object.keys(predObj);
             if (predKeys.length === 1) {
@@ -664,34 +692,34 @@ dbu.buildCondition = function buildCondition (predicates, schema) {
                 switch (predOp.toLowerCase()) {
                 case 'eq':
                     cql += ' = ?';
-                    params.push(convert(predKey, predArg));
+                    params.push(convertFunc(predKey, predArg));
                     break;
                 case 'lt':
                     cql += ' < ?';
-                    params.push(convert(predKey, predArg));
+                    params.push(convertFunc(predKey, predArg));
                     break;
                 case 'gt':
                     cql += ' > ?';
-                    params.push(convert(predKey, predArg));
+                    params.push(convertFunc(predKey, predArg));
                     break;
                 case 'le':
                     cql += ' <= ?';
-                    params.push(convert(predKey, predArg));
+                    params.push(convertFunc(predKey, predArg));
                     break;
                 case 'ge':
                     cql += ' >= ?';
-                    params.push(convert(predKey, predArg));
+                    params.push(convertFunc(predKey, predArg));
                     break;
                 case 'neq':
                 case 'ne':
                     cql += ' != ?';
-                    params.push(convert(predKey, predArg));
+                    params.push(convertFunc(predKey, predArg));
                     break;
                 case 'between':
                         cql += ' >= ?' + ' AND ';
-                        params.push(convert(predKey, predArg[0]));
+                        params.push(convertFunc(predKey, predArg[0]));
                         cql += dbu.cassID(predKey) + ' <= ?';
-                        params.push(convert(predKey, predArg[1]));
+                        params.push(convertFunc(predKey, predArg[1]));
                         break;
                 default: throw new Error ('Operator ' + predOp + ' not supported!');
                 }
@@ -711,9 +739,10 @@ dbu.buildCondition = function buildCondition (predicates, schema) {
 /**
  * CQL building for PUT queries
  * @param {InternalRequest} req
+ * @param {Function} convertFunc the conversion function to use
  * @return {object} queryInfo object with cql and params attributes
  */
-dbu.buildPutQuery = function(req) {
+dbu.buildPutQuery = function(req, convertFunc) {
 
     //table = schema.table;
 
@@ -729,6 +758,13 @@ dbu.buildPutQuery = function(req) {
         attributes._domain = req.domain;
     }
     var conversions = schema.conversions || {};
+    convertFunc = convertFunc || function(attr_key, attr_val) {
+        var conversionObj = conversions[attr_key];
+        if (conversionObj && conversionObj.write) {
+            return conversionObj.write(attr_val);
+        }
+        return attr_val;
+    };
 
     // XXX: should we require non-null secondary index entries too?
     var indexKVMap = {};
@@ -751,10 +787,7 @@ dbu.buildPutQuery = function(req) {
             if (!schema.iKeyMap[key]) {
                 nonIndexKeys.push(key);
                 // Convert the parameter value
-                var conversionObj = conversions[key];
-                if (conversionObj && conversionObj.write) {
-                    val = conversionObj.write(val);
-                }
+                val = convertFunc(key, val);
                 if (val !== null && schema.staticKeyMap && !schema.staticKeyMap[key]) {
                     haveNonIndexNonNullValue = true;
                 }
@@ -794,7 +827,7 @@ dbu.buildPutQuery = function(req) {
         query.if = query.if.trim().split(/\s+/).join(' ').toLowerCase();
     }
 
-    var condRes = dbu.buildCondition(indexKVMap, schema);
+    var condRes = dbu.buildCondition(indexKVMap, schema, convertFunc);
 
     var cond = '';
     if (!haveNonIndexNonNullValue || query.if === 'not exists') {
@@ -812,7 +845,7 @@ dbu.buildPutQuery = function(req) {
         var condParamKeys = [];
         if (query.if) {
             cond = ' if ';
-            condResult = dbu.buildCondition(query.if, schema);
+            condResult = dbu.buildCondition(query.if, schema, convertFunc);
             cond += condResult.cql;
             condParams = condResult.params;
             condParamKeys = condResult.keys;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -671,10 +671,7 @@ dbu.buildCondition = function buildCondition (predicates, schema, noConvert) {
 
     // make sure we have got a predicate object
     if(!predicates || predicates.constructor !== Object) {
-        return {
-            cql: predicates || '',
-            params: []
-        };
+        throw new Error('The condition predicate has not been supplied or is not an Object.');
     }
 
     var params = [];
@@ -828,6 +825,9 @@ dbu.buildPutQuery = function(req, noConvert) {
 
     if (query.if && query.if.constructor === String) {
         query.if = query.if.trim().split(/\s+/).join(' ').toLowerCase();
+        if (query.if !== 'not exists') {
+            throw new Error("Only 'not exists' conditionals are supported.");
+        }
     }
 
     var condRes = dbu.buildCondition(indexKVMap, schema, noConvert);

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -12,9 +12,9 @@ var P = require('bluebird');
  */
 function RevisionPolicyManager(db, request, schema) {
     this.db = db;
-    this.request = dbu.makeRawRequest(request);
     this.schema = schema;
     this.policy = schema.revisionRetentionPolicy;
+    this.request = dbu.makeRawRequest(request, { ttl: this.policy.grace_ttl });
     this.noop = this.policy.type === 'all';
     this.count = 0;
 }
@@ -37,14 +37,21 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
         return P.resolve();
     }
 
-    var request = self.request.extend({ ttl: self.policy.grace_ttl });
-    Object.keys(request.query.attributes).forEach(function(key) {
-        request.query.attributes[key] = row[key];
+    // We want to update the current iteration row, so what needs to
+    // be done is to resend the same row we have received here with a
+    // new timestamp. Modifying self.request in-place is alright since
+    // the requests are sequentially sent, and once executed, the request
+    // object itself is not needed. Also, note that dbu.makeRawRequest()
+    // creates a deep clone of self.request.query, so we are sure not to
+    // modify the original incoming request
+    var attrs = self.request.query.attributes;
+    Object.keys(attrs).forEach(function(key) {
+        attrs[key] = row[key];
     });
-    request.query.timestamp = null;
+    self.request.query.timestamp = null;
 
-    var query = dbu.buildPutQuery(request, true);
-    var queryOptions = { consistency: request.consistency, prepare: true };
+    var query = dbu.buildPutQuery(self.request, true);
+    var queryOptions = { consistency: self.request.consistency, prepare: true };
 
     return self.db.client.execute_p(query.cql, query.params, queryOptions)
     .catch(function(e) {

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -12,7 +12,7 @@ var P = require('bluebird');
  */
 function RevisionPolicyManager(db, request, schema) {
     this.db = db;
-    this.request = dbu.makeConvertedRequest(request);
+    this.request = dbu.makeRawRequest(request);
     this.schema = schema;
     this.policy = schema.revisionRetentionPolicy;
     this.noop = this.policy.type === 'all';

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -2,7 +2,6 @@
 
 var dbu = require('./dbutils');
 var P = require('bluebird');
-var extend = require('extend');
 
 /**
  * Applies a revision retention policy to a sequence of rows.
@@ -13,7 +12,7 @@ var extend = require('extend');
  */
 function RevisionPolicyManager(db, request, schema) {
     this.db = db;
-    this.request = dbu.convertWriteReqQueryAttrs(extend(true, {}, request), schema);
+    this.request = dbu.makeConvertedRequest(request);
     this.schema = schema;
     this.policy = schema.revisionRetentionPolicy;
     this.noop = this.policy.type === 'all';

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -43,7 +43,7 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
     });
     request.query.timestamp = null;
 
-    var query = dbu.buildPutQuery(request, dbu.noConvert);
+    var query = dbu.buildPutQuery(request, true);
     var queryOptions = { consistency: request.consistency, prepare: true };
 
     return self.db.client.execute_p(query.cql, query.params, queryOptions)

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -27,8 +27,6 @@ function RevisionPolicyManager(db, request, schema) {
  */
 RevisionPolicyManager.prototype.handleRow = function(row) {
     var self = this;
-    var reqQuery = {};
-    var request;
 
     if (self.noop) {
         return P.resolve();
@@ -39,21 +37,11 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
         return P.resolve();
     }
 
-    // shallow copy of the query
-    Object.keys(self.request.query).forEach(function(key) {
-        reqQuery[key] = self.request.query[key];
+    var request = self.request.extend({ ttl: self.policy.grace_ttl });
+    Object.keys(request.query.attributes).forEach(function(key) {
+        request.query.attributes[key] = row[key];
     });
-    // mix self.request and row attributes
-    Object.keys(reqQuery.attributes).forEach(function(key) {
-        reqQuery.attributes[key] = row[key] || reqQuery.attributes[key];
-    });
-    // unset the time stamp
-    reqQuery.timestamp = null;
-
-    request = self.request.extend({
-        ttl: self.policy.grace_ttl,
-        query: reqQuery
-    });
+    request.query.timestamp = null;
 
     var query = dbu.buildPutQuery(request, true);
     var queryOptions = { consistency: request.consistency, prepare: true };

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -27,6 +27,8 @@ function RevisionPolicyManager(db, request, schema) {
  */
 RevisionPolicyManager.prototype.handleRow = function(row) {
     var self = this;
+    var reqQuery = {};
+    var request;
 
     if (self.noop) {
         return P.resolve();
@@ -37,11 +39,21 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
         return P.resolve();
     }
 
-    var request = self.request.extend({ ttl: self.policy.grace_ttl });
-    Object.keys(request.query.attributes).forEach(function(key) {
-        request.query.attributes[key] = row[key];
+    // shallow copy of the query
+    Object.keys(self.request.query).forEach(function(key) {
+        reqQuery[key] = self.request.query[key];
     });
-    request.query.timestamp = null;
+    // mix self.request and row attributes
+    Object.keys(reqQuery.attributes).forEach(function(key) {
+        reqQuery.attributes[key] = row[key] || reqQuery.attributes[key];
+    });
+    // unset the time stamp
+    reqQuery.timestamp = null;
+
+    request = self.request.extend({
+        ttl: self.policy.grace_ttl,
+        query: reqQuery
+    });
 
     var query = dbu.buildPutQuery(request, true);
     var queryOptions = { consistency: request.consistency, prepare: true };

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -44,9 +44,8 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
         reqQuery[key] = self.request.query[key];
     });
     // mix self.request and row attributes
-    reqQuery.attributes = {};
-    Object.keys(self.request.query.attributes).forEach(function(key) {
-        reqQuery.attributes[key] = row[key] || self.request.query.attributes[key];
+    Object.keys(reqQuery.attributes).forEach(function(key) {
+        reqQuery.attributes[key] = row[key] || reqQuery.attributes[key];
     });
     // unset the time stamp
     reqQuery.timestamp = null;

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -44,8 +44,9 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
         reqQuery[key] = self.request.query[key];
     });
     // mix self.request and row attributes
-    Object.keys(reqQuery.attributes).forEach(function(key) {
-        reqQuery.attributes[key] = row[key] || reqQuery.attributes[key];
+    reqQuery.attributes = {};
+    Object.keys(self.request.query.attributes).forEach(function(key) {
+        reqQuery.attributes[key] = row[key] || self.request.query.attributes[key];
     });
     // unset the time stamp
     reqQuery.timestamp = null;

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -2,6 +2,7 @@
 
 var dbu = require('./dbutils');
 var P = require('bluebird');
+var extend = require('extend');
 
 /**
  * Applies a revision retention policy to a sequence of rows.
@@ -12,7 +13,7 @@ var P = require('bluebird');
  */
 function RevisionPolicyManager(db, request, schema) {
     this.db = db;
-    this.request = request;
+    this.request = dbu.convertWriteReqQueryAttrs(extend(true, {}, request), schema);
     this.schema = schema;
     this.policy = schema.revisionRetentionPolicy;
     this.noop = this.policy.type === 'all';
@@ -43,7 +44,7 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
     });
     request.query.timestamp = null;
 
-    var query = dbu.buildPutQuery(request);
+    var query = dbu.buildPutQuery(request, dbu.noConvert);
     var queryOptions = { consistency: request.consistency, prepare: true };
 
     return self.db.client.execute_p(query.cql, query.params, queryOptions)

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -109,7 +109,7 @@ IndexRebuilder.prototype.handleRow = function (row) {
             columnfamily: dbu.idxColumnFamily(idx),
             schema: secondarySchema
         });
-        var queryObj = dbu.buildPutQuery(idxReq, dbu.noConvert);
+        var queryObj = dbu.buildPutQuery(idxReq, true);
         queries.push(
             self.db.client.execute_p(queryObj.cql, queryObj.params,
                 { consistency: cass.types.consistencies.one, prepare: true })
@@ -131,7 +131,7 @@ IndexRebuilder.prototype.handleRow = function (row) {
                     timestamp: self.delWriteTimestamp
                 }
             });
-            var delQueryObj = dbu.buildPutQuery(delReq, dbu.noConvert);
+            var delQueryObj = dbu.buildPutQuery(delReq, true);
             queries.push(
                 this.db.client.execute_p(delQueryObj.cql, delQueryObj.params,
                     { consistency: cass.types.consistencies.one, prepare: true })

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -4,11 +4,10 @@ var P = require('bluebird');
 var cass = require('cassandra-driver');
 var TimeUuid = cass.types.TimeUuid;
 var dbu = require('./dbutils');
-var extend = require('extend');
 
 function IndexRebuilder (db, req, secondaryKeys, timestamp) {
     this.db = db;
-    this.req = dbu.convertWriteReqQueryAttrs(extend(true, {}, req));
+    this.req = dbu.makeConvertedRequest(req);
     this.primaryKeys = this.req.schema.iKeys;
     this.secondaryKeys = secondaryKeys;
 

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -4,10 +4,11 @@ var P = require('bluebird');
 var cass = require('cassandra-driver');
 var TimeUuid = cass.types.TimeUuid;
 var dbu = require('./dbutils');
+var extend = require('extend');
 
 function IndexRebuilder (db, req, secondaryKeys, timestamp) {
     this.db = db;
-    this.req = req;
+    this.req = dbu.convertWriteReqQueryAttrs(extend(true, {}, req));
     this.primaryKeys = this.req.schema.iKeys;
     this.secondaryKeys = secondaryKeys;
 
@@ -109,7 +110,7 @@ IndexRebuilder.prototype.handleRow = function (row) {
             columnfamily: dbu.idxColumnFamily(idx),
             schema: secondarySchema
         });
-        var queryObj = dbu.buildPutQuery(idxReq);
+        var queryObj = dbu.buildPutQuery(idxReq, dbu.noConvert);
         queries.push(
             self.db.client.execute_p(queryObj.cql, queryObj.params,
                 { consistency: cass.types.consistencies.one, prepare: true })
@@ -131,7 +132,7 @@ IndexRebuilder.prototype.handleRow = function (row) {
                     timestamp: self.delWriteTimestamp
                 }
             });
-            var delQueryObj = dbu.buildPutQuery(delReq);
+            var delQueryObj = dbu.buildPutQuery(delReq, dbu.noConvert);
             queries.push(
                 this.db.client.execute_p(delQueryObj.cql, delQueryObj.params,
                     { consistency: cass.types.consistencies.one, prepare: true })

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -7,7 +7,7 @@ var dbu = require('./dbutils');
 
 function IndexRebuilder (db, req, secondaryKeys, timestamp) {
     this.db = db;
-    this.req = dbu.makeConvertedRequest(req);
+    this.req = dbu.makeRawRequest(req);
     this.primaryKeys = this.req.schema.iKeys;
     this.secondaryKeys = secondaryKeys;
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "dependencies": {
-    "async": "0.x.x",
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.0.0",
     "extend": "^2.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -316,6 +316,42 @@ describe('DB backend', function() {
                 deepEqual(response, {status:201});
             });
         });
+        it('put with an erroneous conditional if', function() {
+            return router.request({
+                    uri: '/restbase.cassandra.test.local/sys/table/simple-table/',
+                    method: 'put',
+                    body: {
+                        table: "simple-table",
+                        if: "bla = blah",
+                        attributes: {
+                            key: "testing erroneous conditional",
+                            tid: dbu.testTidFromDate(new Date('2013-08-10 18:43:58-0700')),
+                            body: new Buffer("<p>if not exists with non key attr</p>")
+                    }
+                }
+            })
+            .then(function(response) {
+                deepEqual(response.status, 500);
+            });
+        });
+        it('put with a conditional if not an object', function() {
+            return router.request({
+                    uri: '/restbase.cassandra.test.local/sys/table/simple-table/',
+                    method: 'put',
+                    body: {
+                        table: "simple-table",
+                        if: [1, 2, 3],
+                        attributes: {
+                            key: "testing erroneous conditional",
+                            tid: dbu.testTidFromDate(new Date('2013-08-10 18:43:58-0700')),
+                            body: new Buffer("<p>if not exists with non key attr</p>")
+                    }
+                }
+            })
+            .then(function(response) {
+                deepEqual(response.status, 500);
+            });
+        });
         it('put with if and non index attributes', function() {
             return router.request({
                 uri: '/restbase.cassandra.test.local/sys/table/simple-table/',


### PR DESCRIPTION
When a record is added/updated, the asynchronous updates kick in to update the secondary indices and enforce the declared retention policy. However, the original request's attributes are JS types, while all of the retrieved DB rows for which these actions are applied are in native, Cassandra representation, while the code supposed both were JS.

This PR fixes this issue by adding an additional parameter to `buildPutQuery()` and `buildCondition()` allowing users to supply their own conversion function which is applied to a request's query's attributes. This feature is used by the revision policy and the secondary index rebuilder, which supply `dbu.noConvert()`, a dummy conversion function simply returning the value passed in. If this extra parameter is not passed to `buildPutQuery()`, the default conversion scheme is used, thus not affecting the workflow of the other parts of the system.

Additionally, the request query attributes passed to the constructors of `RevisionPolicyManager` and `IndexRebuilder` are converted to the native Cassandra value types to avoid mixing Cassandra and JS types.

Also included in this PR:

- fix minor bug which allowed passing a string to `buildCondition()` instead of an Object - that was happening [here](https://github.com/wikimedia/restbase-mod-table-cassandra/blob/517cd17b82ffdb0ec28d751f03305fbd5f61d104/lib/dbutils.js#L815)
- rename `_get()` to `_getRaw()` to make it clear that method does not perform attribute conversions
- remove the superfluous `async` module dependency
- release v0.7.0