### PR TITLE
More tests refactoring in preparation to move to a separate module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 .tern-project
 .tern-port
 *~
+.idea/*

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -2,10 +2,6 @@
 var crypto = require('crypto');
 var extend = require('extend');
 var cass = require('cassandra-driver');
-var Uuid = cass.types.Uuid;
-var TimeUuid = cass.types.TimeUuid;
-var Integer = cass.types.Integer;
-var BigDecimal = cass.types.BigDecimal;
 var util = require('util');
 var P = require('bluebird');
 var stringify = require('json-stable-stringify');
@@ -59,15 +55,6 @@ dbu.idxColumnFamily = function idxColumnFamily (name, bucket) {
     } else {
         return idx + '_ever';
     }
-};
-
-
-// Create a deterministic TimeUuid from a date. Don't use outside of tests, use
-// TimeUuid.fromDate(date) with proper entropy instead.
-dbu.testTidFromDate = function testTidFromDate(date, useCassTicks) {
-    var tidNode = new Buffer([0x01, 0x23, 0x45, 0x67, 0x89, 0xab]);
-    var tidClock = new Buffer([0x12, 0x34]);
-    return new TimeUuid(date, useCassTicks ? null : 0, tidNode, tidClock);
 };
 
 dbu.tidNanoTime = function(tid) {
@@ -309,7 +296,10 @@ dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
         schema.secondaryIndexes[index] = dbu.validateIndexSchema(schema, schema.secondaryIndexes[index]);
     }
     // Normalize and validate revision retention policy
-    schema.revisionRetentionPolicy = dbu.validateAndNormalizeRevPolicy(schema);
+    var policy = dbu.validateAndNormalizeRevPolicy(schema);
+    if (policy) {
+        schema.revisionRetentionPolicy = policy;
+    }
 
     // XXX: validate attributes
     return schema;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "istanbul": "0.3.5",
     "mocha-lcov-reporter": "0.0.1",
     "mocha": "x.x.x",
-    "mocha-jshint": "0.0.9"
+    "mocha-jshint": "0.0.9",
+    "cassandra-uuid":"^0.0.2"
   }
 }

--- a/test/functional/invalid_requests.js
+++ b/test/functional/invalid_requests.js
@@ -3,12 +3,11 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, context, it, before, beforeEach, after, afterEach */
 
-var deepEqual = require('../utils/test_utils.js').deepEqual;
-var dbu = require('../../lib/dbutils.js');
 var router = require('../utils/test_router.js');
+var utils = require('../utils/test_utils.js');
+var deepEqual = utils.deepEqual;
 
 describe('Invalid request handling', function() {
-
     before(function () { return router.setup(); });
 
     it('fails when writing to non-existent table', function() {
@@ -19,7 +18,7 @@ describe('Invalid request handling', function() {
                 table: 'unknownTable',
                 attributes: {
                     key: 'testing',
-                    tid: dbu.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
+                    tid: utils.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
                 }
             }
         })
@@ -36,7 +35,7 @@ describe('Invalid request handling', function() {
                 table: 'unknownTable',
                 attributes: {
                     key: 'testing',
-                    tid: dbu.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
+                    tid: utils.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
                 }
             }
         })

--- a/test/functional/multi_ranged.js
+++ b/test/functional/multi_ranged.js
@@ -3,9 +3,9 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, context, it, before, beforeEach, after, afterEach */
 
-var deepEqual = require('../utils/test_utils.js').deepEqual;
-var dbu = require('../../lib/dbutils.js');
 var router = require('../utils/test_router.js');
+var utils = require('../utils/test_utils.js');
+var deepEqual = utils.deepEqual;
 
 describe("Multiranged tables", function() {
     this.timeout(15000);
@@ -50,7 +50,7 @@ describe("Multiranged tables", function() {
                 table: "multiRangeTable",
                 attributes: {
                     key: 'testing',
-                    tid: dbu.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
+                    tid: utils.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
                     uri: "test"
                 },
             }

--- a/test/functional/revision_policies.js
+++ b/test/functional/revision_policies.js
@@ -3,10 +3,9 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, context, it, before, beforeEach, after, afterEach */
 
-var assert = require('assert');
-var dbu = require('../../lib/dbutils.js');
-var fs = require('fs');
 var router = require('../utils/test_router.js');
+var assert = require('assert');
+var utils = require('../utils/test_utils.js');
 
 var testSchema = {
     table: 'revPolicyLatestTest',
@@ -65,7 +64,7 @@ describe('MVCC revision policy', function() {
             attributes: {
                 title: 'Revisioned',
                 rev: 1000,
-                tid: dbu.testTidFromDate(new Date("2015-04-01 12:00:00-0500")),
+                tid: utils.testTidFromDate(new Date("2015-04-01 12:00:00-0500")),
                 comment: 'once',
                 author: 'jsmith'
             }
@@ -80,7 +79,7 @@ describe('MVCC revision policy', function() {
                 attributes: {
                     title: 'Revisioned',
                     rev: 1000,
-                    tid: dbu.testTidFromDate(new Date("2015-04-01 12:00:01-0500")),
+                    tid: utils.testTidFromDate(new Date("2015-04-01 12:00:01-0500")),
                     comment: 'twice',
                     author: 'jsmith'
                 }
@@ -95,7 +94,7 @@ describe('MVCC revision policy', function() {
                 attributes: {
                     title: 'Revisioned',
                     rev: 1000,
-                    tid: dbu.testTidFromDate(new Date("2015-04-01 12:00:02-0500")),
+                    tid: utils.testTidFromDate(new Date("2015-04-01 12:00:02-0500")),
                     comment: 'thrice',
                     author: 'jsmith'
                 }

--- a/test/functional/schema_migrations.js
+++ b/test/functional/schema_migrations.js
@@ -3,14 +3,9 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, context, it, before, beforeEach, after, afterEach */
 
-var assert = require('assert');
-var dbu = require('../../lib/dbutils');
-var extend = require('extend');
-var fs = require('fs');
 var router = require('../utils/test_router.js');
-var yaml = require('js-yaml');
-
-var hash = dbu.makeSchemaHash;
+var assert = require('assert');
+var extend = require('extend');
 
 function clone(obj) {
     return extend(true, {}, obj);
@@ -44,7 +39,7 @@ var testTable0 = {
 
 describe('Schema migration', function() {
     before(function() {
-        router.setup()
+        return router.setup()
         .then(function() {
             return router.request({
                 uri: '/restbase.cassandra.test.local/sys/table/testTable0',
@@ -57,6 +52,7 @@ describe('Schema migration', function() {
             });
         });
     });
+
     after(function() {
         return router.request({
             uri: '/restbase.cassandra.test.local/sys/table/testTable0',
@@ -91,7 +87,7 @@ describe('Schema migration', function() {
         .then(function(response) {
             assert.ok(response, 'undefined response');
             assert.deepEqual(response.status, 200);
-            assert.deepEqual(hash(response.body), hash(newSchema));
+            assert.deepEqual(response.body, newSchema);
         });
     });
 
@@ -127,7 +123,6 @@ describe('Schema migration', function() {
         .then(function(response) {
             assert.ok(response);
             assert.deepEqual(response.status, 201);
-
             return router.request({
                 uri: '/restbase.cassandra.test.local/sys/table/testTable0',
                 method: 'GET',
@@ -136,7 +131,7 @@ describe('Schema migration', function() {
         .then(function(response) {
             assert.ok(response, 'undefined response');
             assert.deepEqual(response.status, 200);
-            assert.deepEqual(hash(response.body), hash(newSchema));
+            assert.deepEqual(response.body, newSchema);
         });
     });
 
@@ -162,7 +157,7 @@ describe('Schema migration', function() {
         .then(function(response) {
             assert.ok(response, 'undefined response');
             assert.deepEqual(response.status, 200);
-            assert.deepEqual(hash(response.body), hash(newSchema));
+            assert.deepEqual(response.body, newSchema);
         });
     });
 

--- a/test/functional/secondaryIndexes.js
+++ b/test/functional/secondaryIndexes.js
@@ -3,12 +3,9 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, context, it, before, beforeEach, after, afterEach */
 
-var assert = require('assert');
-var cass = require('cassandra-driver');
 var router = require('../utils/test_router.js');
 var deepEqual = require('../utils/test_utils.js').deepEqual;
-
-var TimeUuid = cass.types.TimeUuid;
+var TimeUuid = require('cassandra-uuid').TimeUuid;
 
 describe('Indices', function() {
 
@@ -56,7 +53,7 @@ describe('Indices', function() {
                     table: "simpleSecondaryIndexTable",
                     attributes: {
                         key: "test",
-                        tid: TimeUuid.now(),
+                        tid: TimeUuid.now().toString(),
                         uri: "uri1",
                         body: 'body1'
                     },
@@ -72,7 +69,7 @@ describe('Indices', function() {
                         table: "simpleSecondaryIndexTable",
                         attributes: {
                             key: "test",
-                            tid: TimeUuid.now(),
+                            tid: TimeUuid.now().toString(),
                             uri: "uri2",
                             body: 'body2'
                         }
@@ -89,7 +86,7 @@ describe('Indices', function() {
                         table: "simpleSecondaryIndexTable",
                         attributes: {
                             key: "test",
-                            tid: TimeUuid.now(),
+                            tid: TimeUuid.now().toString(),
                             uri: "uri3",
                             body: 'body3'
                         },
@@ -106,7 +103,7 @@ describe('Indices', function() {
                         table: "simpleSecondaryIndexTable",
                         attributes: {
                             key: "test2",
-                            tid: TimeUuid.now(),
+                            tid: TimeUuid.now().toString(),
                             uri: "uri1",
                             body: 'test_body1'
                         }
@@ -123,7 +120,7 @@ describe('Indices', function() {
                         table: "simpleSecondaryIndexTable",
                         attributes: {
                             key: "test2",
-                            tid: TimeUuid.now(),
+                            tid: TimeUuid.now().toString(),
                             uri: "uri2",
                             body: 'test_body2'
                         },
@@ -139,7 +136,7 @@ describe('Indices', function() {
                         table: "simpleSecondaryIndexTable",
                         attributes: {
                             key: "test2",
-                            tid: TimeUuid.now(),
+                            tid: TimeUuid.now().toString(),
                             uri: "uri3",
                             body: 'test_body3'
                         }
@@ -156,7 +153,7 @@ describe('Indices', function() {
                         table: "simpleSecondaryIndexTable",
                         attributes: {
                             key: "test2",
-                            tid: TimeUuid.now(),
+                            tid: TimeUuid.now().toString(),
                             uri: "uri3",
                             // Also test projection updates
                             body: 'test_body3_modified'

--- a/test/functional/simple.js
+++ b/test/functional/simple.js
@@ -3,12 +3,9 @@
 // mocha defines to avoid JSHint breakage
 /* global describe, context, it, before, beforeEach, after, afterEach */
 
-var cass = require('cassandra-driver');
-var deepEqual = require('../utils/test_utils.js').deepEqual;
-var dbu = require('../../lib/dbutils.js');
 var router = require('../utils/test_router.js');
-
-var TimeUuid = cass.types.TimeUuid;
+var deepEqual = require('../utils/test_utils.js').deepEqual;
+var utils = require('../utils/test_utils.js');
 var db;
 
 describe('Simple tables', function() {
@@ -112,7 +109,7 @@ describe('Simple tables', function() {
                     consistency: 'localQuorum',
                     attributes: {
                         key: 'testing',
-                        tid: dbu.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
+                        tid: utils.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
                     }
                 }
             })
@@ -128,7 +125,7 @@ describe('Simple tables', function() {
                     table: 'simple-table',
                     attributes: {
                         key: "testing",
-                        tid: dbu.testTidFromDate(new Date('2013-08-09 18:43:58-0700')),
+                        tid: utils.testTidFromDate(new Date('2013-08-09 18:43:58-0700')),
                         body: new Buffer("<p>Service Oriented Architecture</p>")
                     }
                 }
@@ -146,7 +143,7 @@ describe('Simple tables', function() {
                     if : "not exists",
                     attributes: {
                         key: "testing if not exists",
-                        tid: dbu.testTidFromDate(new Date('2013-08-10 18:43:58-0700')),
+                        tid: utils.testTidFromDate(new Date('2013-08-10 18:43:58-0700')),
                         body: new Buffer("<p>if not exists with non key attr</p>")
                     }
                 }
@@ -163,7 +160,7 @@ describe('Simple tables', function() {
                     table: "simple-table",
                     attributes: {
                         key: "another test",
-                        tid: dbu.testTidFromDate(new Date('2013-08-11 18:43:58-0700')),
+                        tid: utils.testTidFromDate(new Date('2013-08-11 18:43:58-0700')),
                         body: new Buffer("<p>test<p>")
                     },
                     if: { body: { "eq": new Buffer("<p>Service Oriented Architecture</p>") } }
@@ -181,8 +178,8 @@ describe('Simple tables', function() {
                     table: 'simple-table',
                     attributes: {
                         key: 'test',
-                        tid: dbu.testTidFromDate(new Date('2013-08-09 18:43:58-0700')),
-                        latestTid: dbu.testTidFromDate(new Date('2014-01-01 00:00:00')),
+                        tid: utils.testTidFromDate(new Date('2013-08-09 18:43:58-0700')),
+                        latestTid: utils.testTidFromDate(new Date('2014-01-01 00:00:00')),
                     }
                 }
             })
@@ -195,9 +192,9 @@ describe('Simple tables', function() {
                         table: 'simple-table',
                         attributes: {
                             key: 'test2',
-                            tid: dbu.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
+                            tid: utils.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
                             body: new Buffer("<p>test<p>"),
-                            latestTid: dbu.testTidFromDate(new Date('2014-01-01 00:00:00')),
+                            latestTid: utils.testTidFromDate(new Date('2014-01-01 00:00:00')),
                         }
                     }
                 });
@@ -211,8 +208,8 @@ describe('Simple tables', function() {
                         table: 'simple-table',
                         attributes: {
                             key: 'test',
-                            tid: dbu.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
-                            latestTid: dbu.testTidFromDate(new Date('2014-01-02 00:00:00'))
+                            tid: utils.testTidFromDate(new Date('2013-08-08 18:43:58-0700')),
+                            latestTid: utils.testTidFromDate(new Date('2014-01-02 00:00:00'))
                         }
                     }
                 });
@@ -232,7 +229,7 @@ describe('Simple tables', function() {
                     table: "simple-table",
                     attributes: {
                         key: 'testing',
-                        tid: dbu.testTidFromDate(new Date('2013-08-08 18:43:58-0700'))
+                        tid: utils.testTidFromDate(new Date('2013-08-08 18:43:58-0700'))
                     }
                 }
             })
@@ -259,8 +256,8 @@ describe('Simple tables', function() {
                     //from: 'foo', // key to start the query from (paging)
                     limit: 3,
                     attributes: {
-                        tid: { "BETWEEN": [ dbu.testTidFromDate(new Date('2013-07-08 18:43:58-0700')),
-                        dbu.testTidFromDate(new Date('2013-08-08 18:45:58-0700'))] },
+                        tid: { "BETWEEN": [ utils.testTidFromDate(new Date('2013-07-08 18:43:58-0700')),
+                            utils.testTidFromDate(new Date('2013-08-08 18:45:58-0700'))] },
                         key: "testing"
                     }
                 }
@@ -287,7 +284,7 @@ describe('Simple tables', function() {
                     proj: ["key", "tid", "latestTid", "body"],
                     attributes: {
                         key: 'test2',
-                        tid: dbu.testTidFromDate(new Date('2013-08-08 18:43:58-0700'))
+                        tid: utils.testTidFromDate(new Date('2013-08-08 18:43:58-0700'))
                     }
                 }
             })
@@ -295,8 +292,8 @@ describe('Simple tables', function() {
                 deepEqual(response.body.items.length, 1);
                 deepEqual(response.body.items[0].key, 'test2');
                 deepEqual(response.body.items[0].body, new Buffer("<p>test<p>"));
-                deepEqual(TimeUuid.fromString(response.body.items[0].latestTid), 
-                          dbu.testTidFromDate(new Date('2014-01-01 00:00:00')));
+                deepEqual(response.body.items[0].latestTid,
+                    utils.testTidFromDate(new Date('2014-01-01 00:00:00')));
                 return router.request({
                     uri:'/restbase.cassandra.test.local/sys/table/simple-table/',
                     method: 'get',
@@ -304,7 +301,7 @@ describe('Simple tables', function() {
                         table: "simple-table",
                         attributes: {
                             key: 'test',
-                            tid: dbu.testTidFromDate(new Date('2013-08-08 18:43:58-0700'))
+                            tid: utils.testTidFromDate(new Date('2013-08-08 18:43:58-0700'))
                         }
                     }
                 });
@@ -313,8 +310,8 @@ describe('Simple tables', function() {
                 deepEqual(response.body.items.length, 1);
                 deepEqual(response.body.items[0].key, 'test');
                 deepEqual(response.body.items[0].tid, '28730300-0095-11e3-9234-0123456789ab');
-                deepEqual(TimeUuid.fromString(response.body.items[0].latestTid),
-                          dbu.testTidFromDate(new Date('2014-01-01 00:00:00')));
+                deepEqual(response.body.items[0].latestTid,
+                    utils.testTidFromDate(new Date('2014-01-01 00:00:00')));
             });
         });
         it('retrieves using order by', function() {
@@ -331,10 +328,10 @@ describe('Simple tables', function() {
             })
             .then(function(response) {
                 deepEqual(response.body.items.length, 2);
-                deepEqual(TimeUuid.fromString(response.body.items[0].latestTid),
-                          dbu.testTidFromDate(new Date('2014-01-01 00:00:00')));
-                deepEqual(TimeUuid.fromString(response.body.items[1].latestTid),
-                          dbu.testTidFromDate(new Date('2014-01-01 00:00:00')));
+                deepEqual(response.body.items[0].latestTid,
+                    utils.testTidFromDate(new Date('2014-01-01 00:00:00')));
+                deepEqual(response.body.items[1].latestTid,
+                    utils.testTidFromDate(new Date('2014-01-01 00:00:00')));
                 delete response.body.items[0].latestTid;
                 delete response.body.items[1].latestTid;
                 deepEqual(response.body.items, [{
@@ -365,7 +362,7 @@ describe('Simple tables', function() {
             return db.delete('restbase.cassandra.test.local', {
                 table: "simple-table",
                 attributes: {
-                    tid: dbu.testTidFromDate(new Date('2013-08-09 18:43:58-0700')),
+                    tid: utils.testTidFromDate(new Date('2013-08-09 18:43:58-0700')),
                     key: "testing"
                 }
             });

--- a/test/functional/simple.js
+++ b/test/functional/simple.js
@@ -6,16 +6,10 @@
 var router = require('../utils/test_router.js');
 var deepEqual = require('../utils/test_utils.js').deepEqual;
 var utils = require('../utils/test_utils.js');
-var db;
 
 describe('Simple tables', function() {
 
-    before(function () { 
-        return router.setup()
-        .then(function(newdb) {
-            db = newdb;
-        });
-    });
+    before(function () { return router.setup(); });
 
     context('Create', function() {
         it('creates a simple test table', function() {
@@ -353,18 +347,6 @@ describe('Simple tables', function() {
                     'content-location': null,
                     restrictions: null,
                 }]);
-            });
-        });
-    });
-
-    context('Delete', function() {
-        it('deletes row', function() {
-            return db.delete('restbase.cassandra.test.local', {
-                table: "simple-table",
-                attributes: {
-                    tid: utils.testTidFromDate(new Date('2013-08-09 18:43:58-0700')),
-                    key: "testing"
-                }
             });
         });
     });

--- a/test/functional/varint.js
+++ b/test/functional/varint.js
@@ -4,7 +4,6 @@
 /* global describe, context, it, before, beforeEach, after, afterEach */
 
 var router = require('../utils/test_router.js');
-var testU = require('../utils/test_utils.js');
 var deepEqual = require('../utils/test_utils.js').deepEqual;
 
 describe('Varint tables', function() {

--- a/test/unit/delete.js
+++ b/test/unit/delete.js
@@ -1,0 +1,70 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var deepEqual = require('../utils/test_utils.js').deepEqual;
+var utils = require('../utils/test_utils.js');
+var fs = require('fs');
+var yaml = require('js-yaml');
+var makeDB = require('../../lib/index.js');
+var db;
+
+describe('Delete', function() {
+    before(function() {
+        var defautOpts = {
+            log: function(level, info) {
+                if (!/^info|verbose|debug|trace|warn/.test(level)) {
+                    console.log(level, info);
+                }
+            },
+            conf: yaml.safeLoad(fs.readFileSync(__dirname + '/../utils/test_router.conf.yaml'))
+        };
+        return makeDB(defautOpts)
+        .then(function(newdb) {
+            db = newdb;
+            return newdb.createTable('restbase.cassandra.test.local', {
+                table: 'simple-table',
+                options: {
+                    durability: 'low',
+                    compression: [
+                        {
+                            algorithm: 'deflate',
+                            block_size: 256
+                        }
+                    ]
+                },
+                attributes: {
+                    key: 'string',
+                    tid: 'timeuuid',
+                    latestTid: 'timeuuid',
+                    body: 'blob',
+                    'content-type': 'string',
+                    'content-length': 'varint',
+                    'content-sha256': 'string',
+                    // redirect
+                    'content-location': 'string',
+                    // 'deleted', 'nomove' etc?
+                    restrictions: 'set<string>',
+                },
+                index: [
+                    {attribute: 'key', type: 'hash'},
+                    {attribute: 'latestTid', type: 'static'},
+                    {attribute: 'tid', type: 'range', order: 'desc'}
+                ]
+            });
+        });
+    });
+
+    // TODO: move to functional tests when delete rest endpoint
+    // is implemented and dependency from impl db can be removed
+    it('deletes row', function() {
+        return db.delete('restbase.cassandra.test.local', {
+            table: "simple-table",
+            attributes: {
+                tid: utils.testTidFromDate(new Date('2013-08-09 18:43:58-0700')),
+                key: "testing"
+            }
+        });
+    });
+});

--- a/test/utils/test_router.js
+++ b/test/utils/test_router.js
@@ -9,7 +9,6 @@ var fs = require('fs');
 var yaml = require('js-yaml');
 
 var RouteSwitch = require('routeswitch');
-var makeClient = require('../../lib/index.js');
 
 function setupConfigDefaults(conf) {
     if (!conf) {
@@ -54,7 +53,7 @@ function flatHandlerFromModDef (modDef, prefix) {
     return handler;
 }
 
-router.makeRouter = function(req) {
+router.makeRouter = function() {
     var self = this;
     var conf = setupConfigDefaults();
     var opt = {
@@ -72,27 +71,8 @@ router.makeRouter = function(req) {
     });
 };
 
-
-var defautOpts = {
-    log: function(level, info) {
-        if (!/^info|verbose|debug|trace|warn/.test(level)) {
-            console.log(level, info);
-        }
-    },
-    conf: yaml.safeLoad(fs.readFileSync( __dirname + '/../utils/test_router.conf.yaml'))
-};
-var isUp = false;
-
-router.setup = function(_options) {
-    var self = this;
-    _options = _options || defautOpts;
-    return makeClient(_options)
-    .then(function(newDb) {
-        return self.makeRouter()
-        .then(function(){
-            return newDb;
-        });
-    })
+router.setup = function() {
+    return this.makeRouter()
     .catch(function(e){console.log(e);});
 };
 

--- a/test/utils/test_utils.js
+++ b/test/utils/test_utils.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var assert = require('assert');
+var TimeUuid = require('cassandra-uuid').TimeUuid;
+
 var testUtils = {};
 
 testUtils.deepEqual = function (result, expected) {
@@ -15,6 +17,12 @@ testUtils.deepEqual = function (result, expected) {
 
 testUtils.roundDecimal = function (item) {
     return Math.round( item * 100) / 100;
+};
+
+testUtils.testTidFromDate = function testTidFromDate(date, useCassTicks) {
+    var tidNode = new Buffer([0x01, 0x23, 0x45, 0x67, 0x89, 0xab]);
+    var tidClock = new Buffer([0x12, 0x34]);
+    return new TimeUuid(date, useCassTicks ? null : 0, tidNode, tidClock).toString();
 };
 
 module.exports = testUtils;


### PR DESCRIPTION
More refactoring is needed on tests to allow moving them to a separate module.

- Replaced cassandra driver's uuid with our cassandra-uuid lib. As constructor is checked by driver, replaced TimeUuid objects with strings everywhere as strings should be correctly handled by both implementations. 
- Removed dependency from functional tests to dbutils: moved testTidFromDate to test_utils as it's used only by tests. Also removed the use of hash function and started to compare plain schema objects which should be fine bc 'hash match' === 'objects match'
- 2 tests were failing - they received unexpected `revisionRetentionPolicy = [ undefined ]`, so I set this schema property only when it's non-empty.
- Fixed one before which didn't return the promise and so could swallow an error.
- Refactored all functional tests to drop dependency from DB and replaced it with calls to router
- Moved one tests from functional to unit, because it depends on deleting a row for table which doesn't yet have a counterpart in routes.

I'm creating this PR to avoid review hell if I change & move files to the separate module simultaneously.

After this functional tests depend only on the test_router, which depends on the library constructor. Constructor would be passed to testing module as parameter, so after this refactoring tests are ready to be moved to separate module.