### PR TITLE
Hotfix: Force limit to actually work on secondary index updates

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -607,9 +607,12 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
         });
         var dataGetInfo = dbu.buildGetQuery(dataGetReq);
 
+        // FIXME: handle this more generically, possibly in buildGetQuery
+        // (requires changes in _get)
+        var limitCQL = parseInt(limit) ? ' limit ' + parseInt(limit) : '';
         return dbu.eachRow(
             self.client,
-            dataGetInfo.cql,
+            dataGetInfo.cql + limitCQL,
             dataGetInfo.params,
             {retries: 3, fetchSize: 5, log: self.log},
             handler.handleRow.bind(handler)


### PR DESCRIPTION
The missing limit functionality here is causing rewrite bursts with on the
order of hundreds of queries per second, which causes OOM and compaction to
lag behind.

This is a hotfix, intended to stop the bleeding until we can clean this up
more thoroughly.

Bug: https://phabricator.wikimedia.org/T105509