### PR TITLE
avoid unnecessary TTL rewrites

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -225,6 +225,7 @@ DB.prototype.get = function (domain, query) {
 
 DB.prototype._getRaw = function (req, options) {
     var self = this;
+    options = options || {};
 
     if (!req.schema) {
         throw new Error("restbase-mod-table-cassandra: No schema for " + req.keyspace
@@ -256,6 +257,10 @@ DB.prototype._getRaw = function (req, options) {
     return self.client.execute_p(buildResult.cql, buildResult.params, cassOpts)
     .then(function(result){
         var rows = result.rows;
+        // Decorate the row result with the _maxTTL attribute.
+        if (options.withTTLs) {
+            rows.forEach(dbu.assignMaxTTL);
+        }
         var length = rows.length;
         for (var i = 0; i < length; i++) {
             if (rows[i]._del) {
@@ -610,7 +615,7 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
             self.client,
             dataGetInfo.cql,
             dataGetInfo.params,
-            {retries: 3, fetchSize: 5, log: self.log},
+            {retries: 3, fetchSize: 5, log: self.log, withTTLs: true},
             handler.handleRow.bind(handler)
         );
     });

--- a/lib/db.js
+++ b/lib/db.js
@@ -597,7 +597,6 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
     })
     .then(function() {       // Query for 'limit' subsequent records
         dataQuery.attributes[schema.tid] = {'lt': reqTid};
-        dataQuery.limit = limit; // typically something around 3, or unlimited
 
         // Traverse the bulk of the data, in timestamp descending order
         // (reverse chronological)
@@ -605,14 +604,11 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
             query: dataQuery,
             columnfamily: 'data',
         });
-        var dataGetInfo = dbu.buildGetQuery(dataGetReq, { withTTLs: true });
+        var dataGetInfo = dbu.buildGetQuery(dataGetReq, { withTTLs: true, limit: limit });
 
-        // FIXME: handle this more generically, possibly in buildGetQuery
-        // (requires changes in _get)
-        var limitCQL = parseInt(limit) ? ' limit ' + parseInt(limit) : '';
         return dbu.eachRow(
             self.client,
-            dataGetInfo.cql + limitCQL,
+            dataGetInfo.cql,
             dataGetInfo.params,
             {retries: 3, fetchSize: 5, log: self.log},
             handler.handleRow.bind(handler)

--- a/lib/db.js
+++ b/lib/db.js
@@ -223,7 +223,7 @@ DB.prototype.get = function (domain, query) {
     });
 };
 
-DB.prototype._getRaw = function (req) {
+DB.prototype._getRaw = function (req, withTTLs) {
     var self = this;
 
     if (!req.schema) {
@@ -252,7 +252,7 @@ DB.prototype._getRaw = function (req) {
         }
     }
 
-    var buildResult = dbu.buildGetQuery(req);
+    var buildResult = dbu.buildGetQuery(req, withTTLs);
     return self.client.execute_p(buildResult.cql, buildResult.params, options)
     .then(function(result){
         var rows = result.rows;
@@ -586,7 +586,7 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
     // Query for a window that includes 1 newer record (if any exists), and up
     // to 'limit' later records.  Run the list of update handlers across each
     // matching row, in descending order.
-    return self._getRaw(newerRebuildRequest)
+    return self._getRaw(newerRebuildRequest, true)
     .then(function(res) {    // Query for one record previous
         return P.try(function() {
             return P.each(res.items.reverse(), handler.handleRow.bind(handler));
@@ -605,7 +605,7 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
             query: dataQuery,
             columnfamily: 'data',
         });
-        var dataGetInfo = dbu.buildGetQuery(dataGetReq);
+        var dataGetInfo = dbu.buildGetQuery(dataGetReq, true);
 
         // FIXME: handle this more generically, possibly in buildGetQuery
         // (requires changes in _get)

--- a/lib/db.js
+++ b/lib/db.js
@@ -223,7 +223,7 @@ DB.prototype.get = function (domain, query) {
     });
 };
 
-DB.prototype._getRaw = function (req, withTTLs) {
+DB.prototype._getRaw = function (req, options) {
     var self = this;
 
     if (!req.schema) {
@@ -242,18 +242,18 @@ DB.prototype._getRaw = function (req, withTTLs) {
     //}
 
     // Paging request:
-    var options = {consistency: req.consistency, prepare: true};
+    var cassOpts = {consistency: req.consistency, prepare: true};
 
     if (req.query.limit) {
-        options.fetchSize = req.query.limit;
+        cassOpts.fetchSize = req.query.limit;
 
         if (req.query.next) {
-            options.pageState = new Buffer( req.query.next, 'base64');
+            cassOpts.pageState = new Buffer( req.query.next, 'base64');
         }
     }
 
-    var buildResult = dbu.buildGetQuery(req, withTTLs);
-    return self.client.execute_p(buildResult.cql, buildResult.params, options)
+    var buildResult = dbu.buildGetQuery(req, options);
+    return self.client.execute_p(buildResult.cql, buildResult.params, cassOpts)
     .then(function(result){
         var rows = result.rows;
         var length = rows.length;
@@ -586,7 +586,7 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
     // Query for a window that includes 1 newer record (if any exists), and up
     // to 'limit' later records.  Run the list of update handlers across each
     // matching row, in descending order.
-    return self._getRaw(newerRebuildRequest, true)
+    return self._getRaw(newerRebuildRequest, { withTTLs: true })
     .then(function(res) {    // Query for one record previous
         return P.try(function() {
             return P.each(res.items.reverse(), handler.handleRow.bind(handler));
@@ -605,7 +605,7 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
             query: dataQuery,
             columnfamily: 'data',
         });
-        var dataGetInfo = dbu.buildGetQuery(dataGetReq, true);
+        var dataGetInfo = dbu.buildGetQuery(dataGetReq, { withTTLs: true });
 
         // FIXME: handle this more generically, possibly in buildGetQuery
         // (requires changes in _get)

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -997,6 +997,14 @@ dbu.buildGetQuery = function(req, options) {
         }
     }
 
+    // Generally, req.query.limit is used to limit per-page results, which is
+    // managed through the driver's pageState.  When it's necessary to use a
+    // CQL LIMIT, it should be included in options.
+    if (options && options.limit) {
+        var limit = parseInt(options.limit);
+        cql += limit ? ' limit ' + limit : '';
+    }
+
     return {cql: cql, params: params};
 };
 

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -901,15 +901,15 @@ dbu.buildGetQuery = function(req, options) {
         req.columnfamily = dbu.idxColumnFamily(query.index);
     }
 
-    var projStr = Object.keys(schema.attributes).map(dbu.cassID).join(',');
+    var projCQL = Object.keys(schema.attributes).map(dbu.cassID).join(',');
     var projAttrs = schema.attributes;
 
     if (query.proj) {
         if (Array.isArray(query.proj)) {
-            projStr = query.proj.map(dbu.cassID).join(',');
+            projCQL = query.proj.map(dbu.cassID).join(',');
             projAttrs = query.proj;
         } else if (query.proj.constructor === String) {
-            projStr = dbu.cassID(query.proj);
+            projCQL = dbu.cassID(query.proj);
             projAttrs = [query.proj];
         }
     }
@@ -919,7 +919,7 @@ dbu.buildGetQuery = function(req, options) {
         // Candidates for TTL are non-index, non-collection, attributes
         var ttlCandidates = Object.keys(projAttrs).filter(
             function(v) {
-                return !schema.iKeyMap[v] && !/(set|map|list)<.+>/.test(schema.attributes[v]);
+                return !schema.iKeyMap[v] && !/^(set|map|list)<.*>$/.test(schema.attributes[v]);
             }
         );
         var projTTLs = ttlCandidates.map(
@@ -927,14 +927,14 @@ dbu.buildGetQuery = function(req, options) {
                 return 'TTL(' + dbu.cassID(v) + ') as ' + dbu.cassID(dbu.cassTTL(v));
             }
         );
-        projStr += ',' + projTTLs.join(',');
+        projCQL += ',' + projTTLs.join(',');
     }
 
     if (query.distinct) {
-        projStr = 'distinct ' + projStr;
+        projCQL = 'distinct ' + projCQL;
     }
 
-    var cql = 'select ' + projStr + ' from '
+    var cql = 'select ' + projCQL + ' from '
         + dbu.cassID(req.keyspace) + '.' + dbu.cassID(req.columnfamily);
 
     // Build up the condition

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -112,6 +112,27 @@ dbu.makeSchemaHash = function makeSchemaHash(schema) {
     return stringify(schema);
 };
 
+/**
+ * Given a row object, adds a _maxTTL attribute for the maximum of all
+ * contained column TTLs, or undefined if no TTLs are present.
+ *
+ * @param {object} row; an object representing a result row
+ */
+dbu.assignMaxTTL = function assignMaxTTL(row) {
+    var max;
+    Object.keys(row).forEach(function(key) {
+        if (/^_ttl_.+/.test(key)) {
+            if (max === undefined) {
+                max = row[key];
+            }
+            else if (row[key] > max) {
+                max = row[key];
+            }
+        }
+    });
+    row._maxTTL = max;
+};
+
 function _nextPage(client, query, params, pageState, options) {
     return P.try(function() {
         return client.execute_p(query, params, {
@@ -148,7 +169,13 @@ dbu.eachRow = function eachRow(client, query, params, options, handler) {
         return _nextPage(client, query, params, pageState, options)
         .then(function(res) {
             return P.try(function() {
-                return P.each(res.rows, handler);
+                return P.each(res.rows, function(row) {
+                    // Decorate the row result with the _maxTTL attribute.
+                    if (options.withTTLs) {
+                        dbu.assignMaxTTL(row);
+                    }
+                    handler(row);
+                });
             }).then(function() {
                 if (!res || res.pageState === null) {
                     return P.resolve();
@@ -886,6 +913,7 @@ dbu.buildPutQuery = function(req, noConvert) {
  * @return {object} queryInfo object with cql and params attributes
  */
 dbu.buildGetQuery = function(req, options) {
+    options = options || {};
     var query = req.query;
     if (!query) {
         throw new Error('Query missing!');
@@ -915,7 +943,7 @@ dbu.buildGetQuery = function(req, options) {
     }
 
     // Add TTL attributes for all non-index attributes
-    if (options && options.withTTLs) {
+    if (options.withTTLs) {
         // Candidates for TTL are non-index, non-collection, attributes
         var ttlCandidates = Object.keys(projAttrs).filter(
             function(v) {
@@ -1000,7 +1028,7 @@ dbu.buildGetQuery = function(req, options) {
     // Generally, req.query.limit is used to limit per-page results, which is
     // managed through the driver's pageState.  When it's necessary to use a
     // CQL LIMIT, it should be included in options.
-    if (options && options.limit) {
+    if (options.limit) {
         var limit = parseInt(options.limit);
         cql += limit ? ' limit ' + limit : '';
     }

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -882,10 +882,10 @@ dbu.buildPutQuery = function(req, noConvert) {
 /**
  * CQL building for GET queries
  * @param {InternalRequest} req
- * @param {Boolean} withTTL if true, return TTLs of non-index attributes
+ * @param  {object} options map
  * @return {object} queryInfo object with cql and params attributes
  */
-dbu.buildGetQuery = function(req, withTTL) {
+dbu.buildGetQuery = function(req, options) {
     var query = req.query;
     if (!query) {
         throw new Error('Query missing!');
@@ -915,7 +915,7 @@ dbu.buildGetQuery = function(req, withTTL) {
     }
 
     // Add TTL attributes for all non-index attributes
-    if (withTTL) {
+    if (options && options.withTTLs) {
         // Candidates for TTL are non-index, non-collection, attributes
         var ttlCandidates = Object.keys(projAttrs).filter(
             function(v) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -48,6 +48,10 @@ dbu.cassID = function cassID (name) {
     }
 };
 
+dbu.cassTTL = function cassTTL(name) {
+    return '_ttl_' + name;
+};
+
 dbu.idxColumnFamily = function idxColumnFamily (name, bucket) {
     var idx = 'idx_' + name;
     if (bucket) {
@@ -878,16 +882,16 @@ dbu.buildPutQuery = function(req, noConvert) {
 /**
  * CQL building for GET queries
  * @param {InternalRequest} req
+ * @param {Boolean} withTTL if true, return TTLs of non-index attributes
  * @return {object} queryInfo object with cql and params attributes
  */
-dbu.buildGetQuery = function(req) {
-    var proj = '*';
-
+dbu.buildGetQuery = function(req, withTTL) {
     var query = req.query;
     if (!query) {
         throw new Error('Query missing!');
     }
     var schema = req.schema;
+
     if (query.index) {
         if (!schema.secondaryIndexes[query.index]) {
             // console.dir(cachedSchema);
@@ -897,26 +901,40 @@ dbu.buildGetQuery = function(req) {
         req.columnfamily = dbu.idxColumnFamily(query.index);
     }
 
+    var projStr = Object.keys(schema.attributes).map(dbu.cassID).join(',');
+    var projAttrs = schema.attributes;
+
     if (query.proj) {
         if (Array.isArray(query.proj)) {
-            proj = query.proj.map(dbu.cassID).join(',');
+            projStr = query.proj.map(dbu.cassID).join(',');
+            projAttrs = query.proj;
         } else if (query.proj.constructor === String) {
-            proj = dbu.cassID(query.proj);
+            projStr = dbu.cassID(query.proj);
+            projAttrs = [query.proj];
         }
-    } else if (query.order) {
-        // Work around 'order by' bug in cassandra when using *
-        // Trying to change the natural sort order only works with a
-        // projection in 2.0.9
-        if (schema) {
-            proj = Object.keys(schema.attributes).map(dbu.cassID).join(',');
-        }
+    }
+
+    // Add TTL attributes for all non-index attributes
+    if (withTTL) {
+        // Candidates for TTL are non-index, non-collection, attributes
+        var ttlCandidates = Object.keys(projAttrs).filter(
+            function(v) {
+                return !schema.iKeyMap[v] && !/(set|map|list)<.+>/.test(schema.attributes[v]);
+            }
+        );
+        var projTTLs = ttlCandidates.map(
+            function(v) {
+                return 'TTL(' + dbu.cassID(v) + ') as ' + dbu.cassID(dbu.cassTTL(v));
+            }
+        );
+        projStr += ',' + projTTLs.join(',');
     }
 
     if (query.distinct) {
-        proj = 'distinct ' + proj;
+        projStr = 'distinct ' + projStr;
     }
 
-    var cql = 'select ' + proj + ' from '
+    var cql = 'select ' + projStr + ' from '
         + dbu.cassID(req.keyspace) + '.' + dbu.cassID(req.columnfamily);
 
     // Build up the condition

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -44,22 +44,10 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
     // object itself is not needed. Also, note that dbu.makeRawRequest()
     // creates a deep clone of self.request.query, so we are sure not to
     // modify the original incoming request
-    var attrs = self.request.query.attributes;
-    var refCount = 0;
-    Object.keys(attrs).forEach(function(key) {
-        var id = dbu.cassTTL(key);
-        if (row.hasOwnProperty(id) && (!row[id] || row[id] >= self.policy.grace_ttl)) {
-            refCount++;
-        }
-        attrs[key] = row[key];
-    });
-
-    // If there were no unset TTLs, or TTLs that would have been lowered
-    // according to the current policy, then avoid a redundant update and bail.
-    if (refCount === 0) {
+    if (row._maxTTL && row._maxTTL <= this.policy.grace_ttl) {
         return P.resolve();
     }
-
+    self.request.query.attributes = row;
     self.request.query.timestamp = null;
 
     var query = dbu.buildPutQuery(self.request, true);

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -45,9 +45,21 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
     // creates a deep clone of self.request.query, so we are sure not to
     // modify the original incoming request
     var attrs = self.request.query.attributes;
+    var refCount = 0;
     Object.keys(attrs).forEach(function(key) {
+        var id = dbu.cassTTL(key);
+        if (row.hasOwnProperty(id) && (!row[id] || row[id] >= self.policy.grace_ttl)) {
+            refCount++;
+        }
         attrs[key] = row[key];
     });
+
+    // If there were no unset TTLs, or TTLs that would have been lowered
+    // according to the current policy, then avoid a redundant update and bail.
+    if (refCount === 0) {
+        return P.resolve();
+    }
+
     self.request.query.timestamp = null;
 
     var query = dbu.buildPutQuery(self.request, true);

--- a/test/unit/dbutils.js
+++ b/test/unit/dbutils.js
@@ -15,7 +15,8 @@ var testTable0a = {
         rev: 'int',
         tid: 'timeuuid',
         comment: 'string',
-        author: 'string'
+        author: 'string',
+        tags: 'set<string>'
     },
     index: [
         { attribute: 'title', type: 'hash' },
@@ -41,7 +42,8 @@ var testTable0b = {
         rev: 'int',
         tid: 'timeuuid',
         author: 'string',
-        comment: 'string'
+        comment: 'string',
+        tags: 'set<string>'
     },
     domain: 'restbase.cassandra.test.local',
     secondaryIndexes: {
@@ -59,12 +61,47 @@ var testTable0b = {
     ]
 };
 
-
 describe('DB utilities', function() {
     it('generates deterministic hash', function() {
         assert.deepEqual(
             dbu.makeSchemaHash(testTable0a),
             dbu.makeSchemaHash(testTable0b));
+    });
+
+    it('builds SELECTs with included TTLs', function() {
+        var req = {
+            keyspace: 'keyspace',
+            columnfamily: 'columnfamily',
+            domain: 'en.wikipedia.org',
+            schema: dbu.makeSchemaInfo(dbu.validateAndNormalizeSchema(testTable0a)),
+            query: {},
+        };
+        var statement = dbu.buildGetQuery(req, true);
+        var match = statement.cql.match(/select (.+) from .+$/i);
+
+        assert(match.length === 2, 'result has no matching projection');
+
+        var projs = match[1].split(',').map(function(i) { return i.trim(); });
+
+        var exp = /TTL\((.+)\) as "_ttl_(.+)"/;
+
+        // There should be 8 non-ttl attributes total.
+        assert(projs.filter(function(v) { return !exp.test(v); }).length === 8);
+
+        var matching = [];
+        projs.filter(function(v) { return exp.test(v); }).forEach(
+            function(v) {
+                var v1 = v.match(exp)[1];
+                var v2 = v.match(exp)[2];
+                assert.deepEqual(v1, dbu.cassID(v2));
+                matching.push(v2);
+            }
+        );
+
+        // matching should include _del, author, and comment only; should only
+        // include non-index, and non-collection attributes.
+        assert(matching.length === 3, 'incorrect number of TTL\'d attributes');
+        assert.deepEqual(matching.sort(), ["_del", "author", "comment"]);
     });
 });
 

--- a/test/unit/dbutils.js
+++ b/test/unit/dbutils.js
@@ -103,6 +103,18 @@ describe('DB utilities', function() {
         assert(matching.length === 3, 'incorrect number of TTL\'d attributes');
         assert.deepEqual(matching.sort(), ["_del", "author", "comment"]);
     });
+
+    it('builds SELECTS with an included LIMIT', function() {
+        var req = {
+            keyspace: 'keyspace',
+            columnfamily: 'columnfamily',
+            domain: 'en.wikipedia.org',
+            schema: dbu.makeSchemaInfo(dbu.validateAndNormalizeSchema(testTable0a)),
+            query: {},
+        };
+        var cql = dbu.buildGetQuery(req, { limit: 42 }).cql;
+        assert(cql.toLowerCase().includes('limit 42'), 'missing limit clause');
+    });
 });
 
 describe('Schema validation', function() {

--- a/test/unit/dbutils.js
+++ b/test/unit/dbutils.js
@@ -76,7 +76,7 @@ describe('DB utilities', function() {
             schema: dbu.makeSchemaInfo(dbu.validateAndNormalizeSchema(testTable0a)),
             query: {},
         };
-        var statement = dbu.buildGetQuery(req, true);
+        var statement = dbu.buildGetQuery(req, { withTTLs: true });
         var match = statement.cql.match(/select (.+) from .+$/i);
 
         assert(match.length === 2, 'result has no matching projection');


### PR DESCRIPTION
Refactored dbu#buildGetQuery to treat the default projection (*), as an
explicit set of attributes.  This avoids the special-casing for 2.0.x versions,
and makes appending TTL attributes more straightforward.

Introduced a boolean parameter to db#_getRaw and dbu#buildGetQuery to specify
results that include a TTL attribute for all candidates (candidates being any
non-index, non-collection attribute).

Added TTL results to the queries performed in db#_backgroundUpdates, and
utilized them to avoid rewriting rows that have already had a TTL set.

Bug: T105509