### PR TITLE
Compare with a fixed date

### DIFF
--- a/maintenance/thin_out_key_rev_value_data.js
+++ b/maintenance/thin_out_key_rev_value_data.js
@@ -121,7 +121,7 @@ function processRow (row) {
         || (counts.rev === 0 && counts.render > 0
             // Enforce a grace_ttl of 86400
             && (Date.now() - row.tid.getDate()) > 86400000)
-        || (counts.rev > 0 && (Date.now() - row.tid.getDate()) > (86400000 * 60))) {
+        || (counts.rev > 0 && row.tid.getDate() < Date.parse('2015-07-10T13:00-0700'))) {
         console.log('-- deleting: ', keys.rev, new Date(row.tid.getDate()));
         var delQuery = 'delete from data where "_domain" = :domain and key = :key and rev = :rev and tid = :tid';
         row.domain = row._domain;


### PR DESCRIPTION
When thinning both html and data-parsoid it's easier to maintain a clean
cut-off when comparing with a fixed date.