### PR TITLE
Update cassandra-driver to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.7.5",
   "dependencies": {
     "bluebird": "~2.8.2",
-    "cassandra-driver": "~2.0.0",
+    "cassandra-driver": "~2.1.2",
     "extend": "^2.0.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "js-yaml": "^3.2.5",


### PR DESCRIPTION
- https://github.com/datastax/nodejs-driver/releases/tag/v2.1.0
- https://github.com/datastax/nodejs-driver/releases/tag/v2.1.1
- https://github.com/datastax/nodejs-driver/releases/tag/v2.1.2