### PR TITLE
Make background updates synchronous

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -479,11 +479,11 @@ DB.prototype._put = function(req) {
 
     //console.log(batch, schema);
     var queryOptions = {consistency: req.consistency, prepare: true};
-    var mainUpdate;
+    var update;
     if (batch.length === 1) {
         // Single query only (no secondary indexes): no need for a batch.
         var queryInfo = batch[0];
-        mainUpdate = this.client.execute_p(queryInfo.cql, queryInfo.params, queryOptions);
+        update = this.client.execute_p(queryInfo.cql, queryInfo.params, queryOptions);
     } else {
         var driverBatch = batch.map(function(queryInfo) {
             return {
@@ -491,26 +491,40 @@ DB.prototype._put = function(req) {
                 params: queryInfo.params
             };
         });
-        mainUpdate = this.client.batch_p(driverBatch, queryOptions);
+        update = this.client.batch_p(driverBatch, queryOptions);
     }
 
-    return mainUpdate
+    if (self._shouldRunBackgroundUpdates(schema))
+    {
+        update = update.then(function() {
+            return self._backgroundUpdates(req, 3);
+        });
+    }
 
-    .then(function(result) {
-        // Kick off asynchronous local index rebuild
-        if (schema.secondaryIndexes) {
-            self._backgroundUpdates(req, 3)
-            .catch(function(err) {
-                self.log('error/cassandra/backgroundUpdates', err);
-            });
-        }
-
-        // But don't wait for it. Return success straight away.
+    return update.then(function(result) {
         return {
             // XXX: check if condition failed!
             status: 201
         };
     });
+};
+
+/*
+ * Predicate: should we run background updates?
+ *
+ * @param {object} schema; the table schema
+ * @param {array} (optional) indexes to process
+ * @return {boolean} whether to apply background updates
+ */
+DB.prototype._shouldRunBackgroundUpdates = function(schema, indexes) {
+    if (!indexes) {
+        indexes = Object.keys(schema.secondaryIndexes);
+    }
+    // If there are no indexes, and the retention policy is 'all' (i.e.
+    // there are no revisions to cull), then there is no need to run
+    // background updates.
+    return indexes.length
+        || schema.revisionRetentionPolicy && schema.revisionRetentionPolicy.type !== 'all';
 };
 
 /*
@@ -531,11 +545,10 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
     var self = this;
     var schema = req.schema;
     var query = req.query;
-    indexes = indexes || Object.keys(schema.secondaryIndexes);
 
-    // If there are no indexes, and the retention policy is 'all' (i.e.
-    // there are no revisions to cull), then there is no need to go further.
-    if (!indexes.length && schema.revisionRetentionPolicy.type === 'all') {
+    indexes = indexes || Object.keys(schema.secondaryIndexes);
+    if (!self._shouldRunBackgroundUpdates(schema, indexes)) {
+        // nothing to do.
         return P.resolve();
     }
 


### PR DESCRIPTION
With idempotent updates it is better to retry the put at a higher level if
necessary. Consumers can still choose to ignore failures, but now have a
chance to repeat requests in case any part of the request processing fails.

This change should provide better back-pressure in write overload situations
by slowing those requests down until the request is fully processed. As a
consequence, it should reduce the memory build-up in restbase when writes are
slow.

As a 'small' bug fix, this patch also makes sure that background updates are run
whenever a retention policy other than 'all' is specified, even if no
secondary indexes are defined on the table.