### PR TITLE
Implemented 'interval' policy support

### DIFF
--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -19,8 +19,13 @@ function RevisionPolicyManager(db, request, schema) {
     // The latest / just inserted row is not processed by the retentionPolicy,
     // so start with count 1.
     this.count = 1;
-    this.candidates = [];
-    this.candidatesFlushed = false;
+    if (this.policy.type === 'interval') {
+        var interval = this.policy.interval * 1000;
+        var tidTime = this.request.query.timestamp;
+        this.intervalLimitTime = tidTime - tidTime % interval;
+    } else {
+        this.intervalLimitTime = null;
+    }
 }
 
 /**
@@ -67,15 +72,10 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
         }
         return setTtl(row);
     } else if (this.policy.type === 'interval') {
-        var interval = this.policy.interval * 1000;
-
-        var tidTime = this.request.query.timestamp;
-        var intervalLimitTime = new Date(tidTime - interval);
-        if (row[this.schema.tid].getDate() > intervalLimitTime && !row._ttl) {
-            this.candidates.push(row);
-        } else if (!this.candidatesFlushed) {
-            this.candidatesFlushed = true;
-            return P.all(this.candidates.map(setTtl));
+        if (row[this.schema.tid].getDate() > this.intervalLimitTime && !row._ttl) {
+            return setTtl(row);
+        } else {
+            return P.resolve();
         }
     }
 };

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -19,6 +19,8 @@ function RevisionPolicyManager(db, request, schema) {
     // The latest / just inserted row is not processed by the retentionPolicy,
     // so start with count 1.
     this.count = 1;
+    this.candidates = [];
+    this.candidatesFlushed = false;
 }
 
 /**
@@ -30,6 +32,19 @@ function RevisionPolicyManager(db, request, schema) {
 RevisionPolicyManager.prototype.handleRow = function(row) {
     var self = this;
 
+    function setTtl(item) {
+        self.request.query.attributes = item;
+        self.request.query.timestamp = null;
+
+        var query = dbu.buildPutQuery(self.request, true);
+        var queryOptions = {consistency: self.request.consistency, prepare: true};
+
+        return self.db.client.execute_p(query.cql, query.params, queryOptions)
+        .catch(function(e) {
+            self.db.log('error/table/cassandra/revisionRetentionPolicyUpdate', e);
+        });
+    }
+
     if (self.noop) {
         return P.resolve();
     }
@@ -39,26 +54,30 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
         return P.resolve();
     }
 
-    // We want to update the current iteration row, so what needs to
-    // be done is to resend the same row we have received here with a
-    // new timestamp. Modifying self.request in-place is alright since
-    // the requests are sequentially sent, and once executed, the request
-    // object itself is not needed. Also, note that dbu.makeRawRequest()
-    // creates a deep clone of self.request.query, so we are sure not to
-    // modify the original incoming request
-    if (row._ttl && row._ttl <= this.policy.grace_ttl) {
-        return P.resolve();
+    if (this.policy.type === 'latest') {
+        // We want to update the current iteration row, so what needs to
+        // be done is to resend the same row we have received here with a
+        // new timestamp. Modifying self.request in-place is alright since
+        // the requests are sequentially sent, and once executed, the request
+        // object itself is not needed. Also, note that dbu.makeRawRequest()
+        // creates a deep clone of self.request.query, so we are sure not to
+        // modify the original incoming request
+        if (row._ttl && row._ttl <= this.policy.grace_ttl) {
+            return P.resolve();
+        }
+        return setTtl(row);
+    } else if (this.policy.type === 'interval') {
+        var interval = this.policy.interval * 1000;
+
+        var tidTime = this.request.query.timestamp;
+        var intervalLimitTime = new Date(tidTime - interval);
+        if (row[this.schema.tid].getDate() > intervalLimitTime && !row._ttl) {
+            this.candidates.push(row);
+        } else if (!this.candidatesFlushed) {
+            this.candidatesFlushed = true;
+            this.candidates.forEach(setTtl);
+        }
     }
-    self.request.query.attributes = row;
-    self.request.query.timestamp = null;
-
-    var query = dbu.buildPutQuery(self.request, true);
-    var queryOptions = { consistency: self.request.consistency, prepare: true };
-
-    return self.db.client.execute_p(query.cql, query.params, queryOptions)
-    .catch(function(e) {
-        self.db.log('error/table/cassandra/revisionRetentionPolicyUpdate', e);
-    });
 };
 
 module.exports = {

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -28,6 +28,20 @@ function RevisionPolicyManager(db, request, schema) {
     }
 }
 
+RevisionPolicyManager.prototype._setTtl = function(item) {
+    var self = this;
+    self.request.query.attributes = item;
+    self.request.query.timestamp = null;
+
+    var query = dbu.buildPutQuery(self.request, true);
+    var queryOptions = {consistency: self.request.consistency, prepare: true};
+
+    return self.db.client.execute_p(query.cql, query.params, queryOptions)
+    .catch(function(e) {
+        self.db.log('error/table/cassandra/revisionRetentionPolicyUpdate', e);
+    });
+};
+
 /**
  * Process one row in the sequence.
  *
@@ -36,19 +50,6 @@ function RevisionPolicyManager(db, request, schema) {
  */
 RevisionPolicyManager.prototype.handleRow = function(row) {
     var self = this;
-
-    function setTtl(item) {
-        self.request.query.attributes = item;
-        self.request.query.timestamp = null;
-
-        var query = dbu.buildPutQuery(self.request, true);
-        var queryOptions = {consistency: self.request.consistency, prepare: true};
-
-        return self.db.client.execute_p(query.cql, query.params, queryOptions)
-        .catch(function(e) {
-            self.db.log('error/table/cassandra/revisionRetentionPolicyUpdate', e);
-        });
-    }
 
     if (self.noop) {
         return P.resolve();
@@ -70,10 +71,10 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
         if (row._ttl && row._ttl <= this.policy.grace_ttl) {
             return P.resolve();
         }
-        return setTtl(row);
+        return self._setTtl(row);
     } else if (this.policy.type === 'interval') {
         if (row[this.schema.tid].getDate() > this.intervalLimitTime && !row._ttl) {
-            return setTtl(row);
+            return self._setTtl(row);
         } else {
             return P.resolve();
         }

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -75,7 +75,7 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
             this.candidates.push(row);
         } else if (!this.candidatesFlushed) {
             this.candidatesFlushed = true;
-            this.candidates.forEach(setTtl);
+            return P.all(this.candidates.map(setTtl));
         }
     }
 };

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -73,7 +73,7 @@ RevisionPolicyManager.prototype.handleRow = function(row) {
         }
         return self._setTtl(row);
     } else if (this.policy.type === 'interval') {
-        if (row[this.schema.tid].getDate() > this.intervalLimitTime && !row._ttl) {
+        if (row[this.schema.tid].getDate() >= this.intervalLimitTime && !row._ttl) {
             return self._setTtl(row);
         } else {
             return P.resolve();

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.1.2",
     "extend": "^2.0.0",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
     "js-yaml": "^3.2.5",
-    "restbase-mod-table-spec": "^0.0.2"
+    "restbase-mod-table-spec": "^0.0.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The PR implements an interval option for revision retention policy for Cassandra backend using and algorithm, described in a ticket.

Note: this PR depends on spec one: wikimedia/restbase-mod-table-spec#12

Bug: https://phabricator.wikimedia.org/T94524