### PR TITLE
multi-datacenter replication

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -687,6 +687,107 @@ DB.prototype._migrateBackend = function(req, from, to) {
     }
 };
 
+/**
+ * Conditionally performs a table schema and/or back-end migration.
+ *
+ * @param  {object} req;               the current request object
+ * @param  {object} currentSchemaInfo; schema info object for current schema
+ * @param  {object} newSchema;         the proposed schema
+ * @param  {object} newSchemaInfo;     schema info object for proposed schema
+ * @return {object} HTTP response
+ */
+DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, newSchemaInfo) {
+    var self = this;
+
+    var migrationPromise = P.resolve();
+    var emptyPromise = migrationPromise;
+
+    // The _backend_version attribute is excluded from the schema hash
+    // calculation so that we can evaluate these different classes of
+    // change (_backend_version versus table schema) separately.  If
+    // backend versions differ, a backend migration will need to be
+    // performed first.  Afterward, if and only if there has been a
+    // change to the schema (that is if the hashes do not match), will
+    // a schema migration occur. These schema changes must also include
+    // a monotonically increasing version number.  Finally, if either
+    // (or both) of a backend or table schema migration occur, the new
+    // JSON blob will be persisted.
+
+    // First carry out any back-end migration (if needed).
+    if (currentSchemaInfo._backend_version !== newSchemaInfo._backend_version) {
+        // A downgrade (unsupported)!
+        if (newSchemaInfo._backend_version < currentSchemaInfo._backend_version) {
+            throw new dbu.HTTPError({
+                status: 400,
+                body: {
+                    type: 'bad_request',
+                    title: 'Unable to downgrade storage backend to version '+newSchemaInfo._backend_version,
+                    keyspace: req.keyspace,
+                    schema: newSchema
+                }
+            });
+        }
+        
+        migrationPromise = self._migrateBackend(req, currentSchemaInfo, newSchemaInfo);
+    }
+
+    // Next carry out any table schema migration (if needed).
+    if (currentSchemaInfo.hash !== newSchemaInfo.hash) {
+        var migrator;
+        try {
+            migrator = new SchemaMigrator(
+                self,
+                req,
+                currentSchemaInfo,
+                newSchemaInfo);
+        }
+        catch (error) {
+            throw new dbu.HTTPError({
+                status: 400,
+                body: {
+                    type: 'bad_request',
+                    title: 'The table already exists, and it cannot be upgraded to the requested schema ('+error+').',
+                    keyspace: req.keyspace,
+                    schema: newSchema
+                }
+            });
+        }
+        migrationPromise = migrationPromise.then(migrator.migrate.bind(migrator));
+    }
+
+    // Finally, if there are any migrations, apply them and persist.
+    if (migrationPromise !== emptyPromise) {
+        return migrationPromise
+            .then(function() {
+                var putReq = req.extend({
+                    columnfamily: 'meta',
+                    schema: self.infoSchemaInfo,
+                    query: {
+                        attributes: {
+                            key: 'schema',
+                            value: newSchema
+                        }
+                    }
+                });
+                return self._put(putReq)
+                    .then(function() {
+                        // Force a cache update on subsequent requests
+                        self._initSchemaCache();
+                        return { status: 201 };
+                    })
+                    .catch(function(error) {
+                        self.log('error/cassandra/table_update', error);
+                        throw error;
+                    });
+            });
+    }
+    else {
+        return {
+            status: 201
+        };
+    }
+};
+
 DB.prototype.createTable = function (domain, query) {
     var self = this;
     if (!query.table) {
@@ -707,93 +808,7 @@ DB.prototype.createTable = function (domain, query) {
 
         if (currentSchemaInfo) {
             // Table already exists
-            var migrationPromise = P.resolve();
-            var emptyPromise = migrationPromise;
-
-            // The _backend_version attribute is excluded from the schema hash
-            // calculation so that we can evaluate these different classes of
-            // change (_backend_version versus table schema) separately.  If
-            // backend versions differ, a backend migration will need to be
-            // performed first.  Afterward, if and only if there has been a
-            // change to the schema (that is if the hashes do not match), will
-            // a schema migration occur. These schema changes must also include
-            // a monotonically increasing version number.  Finally, if either
-            // (or both) of a backend or table schema migration occur, the new
-            // JSON blob will be persisted.
-
-            // First carry out any back-end migration (if needed).
-            if (currentSchemaInfo._backend_version !== newSchemaInfo._backend_version) {
-                // A downgrade (unsupported)!
-                if (newSchemaInfo._backend_version < currentSchemaInfo._backend_version) {
-                    throw new dbu.HTTPError({
-                        status: 400,
-                        body: {
-                            type: 'bad_request',
-                            title: 'Unable to downgrade storage backend to version '+newSchemaInfo._backend_version,
-                            keyspace: req.keyspace,
-                            schema: newSchema
-                        }
-                    });
-                }
-
-                migrationPromise = self._migrateBackend(req, currentSchemaInfo, newSchemaInfo);
-            }
-
-            // Next carry out any table schema migration (if needed).
-            if (currentSchemaInfo.hash !== newSchemaInfo.hash) {
-                var migrator;
-                try {
-                    migrator = new SchemaMigrator(
-                        self,
-                        req,
-                        currentSchemaInfo,
-                        newSchemaInfo);
-                }
-                catch (error) {
-                    throw new dbu.HTTPError({
-                        status: 400,
-                        body: {
-                            type: 'bad_request',
-                            title: 'The table already exists, and it cannot be upgraded to the requested schema ('+error+').',
-                            keyspace: req.keyspace,
-                            schema: newSchema
-                        }
-                    });
-                }
-                migrationPromise = migrationPromise.then(migrator.migrate.bind(migrator));
-            }
-
-            // Finally, if there are any migrations, apply them and persist.
-            if (migrationPromise !== emptyPromise) {
-                return migrationPromise
-                .then(function() {
-                    var putReq = req.extend({
-                        columnfamily: 'meta',
-                        schema: self.infoSchemaInfo,
-                        query: {
-                            attributes: {
-                                key: 'schema',
-                                value: newSchema
-                            }
-                        }
-                    });
-                    return self._put(putReq)
-                    .then(function() {
-                        // Force a cache update on subsequent requests
-                        self._initSchemaCache();
-                        return { status: 201 };
-                    })
-                    .catch(function(error) {
-                        self.log('error/cassandra/table_update', error);
-                        throw error;
-                    });
-                });
-            }
-            else {
-                return {
-                    status: 201
-                };
-            }
+            return self._migrateIfNecessary(req, currentSchemaInfo, newSchema, newSchemaInfo);
         }
 
         // Cassandra does not like concurrent keyspace creation. This is

--- a/lib/db.js
+++ b/lib/db.js
@@ -796,21 +796,6 @@ DB.prototype.createTable = function (domain, query) {
             }
         }
 
-        // TODO:2014-11-09:gwicke use info from system.{peers,local} to
-        // automatically set up DC replication
-        //
-        // Always use NetworkTopologyStrategy with default 'datacenter1' for easy
-        // extension to cross-DC replication later.
-        var localDc = self.conf.localDc;
-        var replicationOptions = "{ 'class': 'NetworkTopologyStrategy', '" + localDc + "': 3 }";
-
-        if (req.query.options) {
-            if (req.query.options.durability === 'low') {
-                replicationOptions = "{ 'class': 'NetworkTopologyStrategy', '" + localDc + "': 1 }";
-            }
-        }
-
-
         // Cassandra does not like concurrent keyspace creation. This is
         // especially significant on the first restbase startup, when many workers
         // compete to create the system tables. It is also relevant for complex
@@ -829,7 +814,7 @@ DB.prototype.createTable = function (domain, query) {
         var retries = 100; // We try really hard.
         var delay = 100; // Start with a 1ms delay
         function doCreateTables() {
-            return self._createKeyspace(req, replicationOptions)
+            return self._createKeyspace(req)
             .then(function() {
                 return self._createTable(req, newSchemaInfo, 'data');
             })
@@ -972,13 +957,22 @@ DB.prototype._dropDomainIndex = function(req) {
     });
 };
 
-DB.prototype._createKeyspace = function (req, options) {
+DB.prototype._createKeyspace = function (req) {
     var cql = 'create keyspace if not exists ' + cassID(req.keyspace)
-        + ' WITH REPLICATION = ' + options;
+        + ' WITH REPLICATION = ' + this._createReplicationOptionsCQL(req.query.options);
     return this.client.execute_p(cql, [],
             {consistency: req.consistency || this.defaultConsistency});
 };
 
+DB.prototype._createReplicationOptionsCQL = function(options) {
+    var durability = (options && options.durability === 'low') ? 1 : 3;
+    var cql = "{ 'class': 'NetworkTopologyStrategy'";
+    this.conf.datacenters.forEach(function(dc) {
+        cql += ", '" + dc + "': " + durability;
+    });
+    cql += '}';
+    return cql;
+};
 
 DB.prototype.dropTable = function (domain, table) {
     var keyspace = this._keyspaceName(domain, table);

--- a/lib/db.js
+++ b/lib/db.js
@@ -746,7 +746,7 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
                 status: 400,
                 body: {
                     type: 'bad_request',
-                    title: 'The table already exists, and it cannot be upgraded to the requested schema ('+error+').',
+                    title: 'The table already exists, and it cannot be upgraded to the requested schema (' + error + ').',
                     keyspace: req.keyspace,
                     schema: newSchema
                 }
@@ -758,30 +758,29 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
     // Finally, if there are any migrations, apply them and persist.
     if (migrationPromise !== emptyPromise) {
         return migrationPromise
-            .then(function() {
-                var putReq = req.extend({
-                    columnfamily: 'meta',
-                    schema: self.infoSchemaInfo,
-                    query: {
-                        attributes: {
-                            key: 'schema',
-                            value: newSchema
-                        }
+        .then(function() {
+            var putReq = req.extend({
+                columnfamily: 'meta',
+                schema: self.infoSchemaInfo,
+                query: {
+                    attributes: {
+                        key: 'schema',
+                        value: newSchema
                     }
-                });
-                return self._put(putReq)
-                    .then(function() {
-                        // Force a cache update on subsequent requests
-                        self._initSchemaCache();
-                        return { status: 201 };
-                    })
-                    .catch(function(error) {
-                        self.log('error/cassandra/table_update', error);
-                        throw error;
-                    });
+                }
             });
-    }
-    else {
+            return self._put(putReq)
+            .then(function() {
+                // Force a cache update on subsequent requests
+                self._initSchemaCache();
+                return { status: 201 };
+            })
+            .catch(function(error) {
+                self.log('error/cassandra/table_update', error);
+                throw error;
+            });
+        });
+    } else {
         return {
             status: 201
         };
@@ -983,7 +982,6 @@ DB.prototype._createKeyspace = function (req) {
 };
 
 DB.prototype._createReplicationOptionsCQL = function(options) {
-    var durability = (options && options.durability === 'low') ? 1 : 3;
     var cql = "{ 'class': 'NetworkTopologyStrategy'";
     var replicas = this._replicationPolicy(options);
 
@@ -1087,7 +1085,7 @@ DB.prototype._setReplication = function(domain, table, options) {
  * if necessary.
  *
  * NOTE: All this does is ALTER the underlying Cassandra keyspace, a repair (or
- * cleanup) is is still necessary.
+ * cleanup) is still necessary.
  *
  * @param  {string} domain;  the domain name
  * @param  {string} table;   the table name

--- a/lib/db.js
+++ b/lib/db.js
@@ -808,7 +808,10 @@ DB.prototype.createTable = function (domain, query) {
 
         if (currentSchemaInfo) {
             // Table already exists
-            return self._migrateIfNecessary(req, currentSchemaInfo, newSchema, newSchemaInfo);
+            return self._updateReplicationIfNecessary(domain, query.table, req.query.options)
+            .then(function() {
+                return self._migrateIfNecessary(req, currentSchemaInfo, newSchema, newSchemaInfo);
+            });
         }
 
         // Cassandra does not like concurrent keyspace creation. This is
@@ -982,11 +985,23 @@ DB.prototype._createKeyspace = function (req) {
 DB.prototype._createReplicationOptionsCQL = function(options) {
     var durability = (options && options.durability === 'low') ? 1 : 3;
     var cql = "{ 'class': 'NetworkTopologyStrategy'";
-    this.conf.datacenters.forEach(function(dc) {
-        cql += ", '" + dc + "': " + durability;
+    var replicas = this._replicationPolicy(options);
+
+    Object.keys(replicas).forEach(function(dc) {
+        cql += ", '" + dc + "': " + replicas[dc];
     });
+
     cql += '}';
     return cql;
+};
+
+DB.prototype._replicationPolicy = function(options) {
+    var durability = (options && options.durability === 'low') ? 1 : 3;
+    var replicas = {};
+    this.conf.datacenters.forEach(function(dc) {
+        replicas[dc] = durability;
+    });
+    return replicas;
 };
 
 DB.prototype.dropTable = function (domain, table) {
@@ -1019,6 +1034,84 @@ DB.prototype.getTableSchema = function(domain, table) {
         }
         var item = response.items[0];
         return { tid: item.tid, schema: JSON.parse(item.value) };
+    });
+};
+
+/**
+ * Retrieves the current replication options for a keyspace.
+ *
+ * @param  {string} domain; the domain name
+ * @param  {string} table;  the table name
+ * @return {object} promise that yields an associative array of datacenters with
+ *                  corresponding replication counts 
+ */
+DB.prototype._getReplication = function(domain, table) {
+    var cacheKey = JSON.stringify([domain,table]);
+    var keyspace = this.keyspaceNameCache[cacheKey] || this._keyspaceName(domain, table);
+    var cql = "SELECT strategy_options FROM system.schema_keyspaces WHERE keyspace_name = '" + keyspace + "'";
+    return this.client.execute_p(cql, [], {consistency: this.defaultConsistency})
+    .then(function(res) {
+        var jsonOpts = res.rows.length ? res.rows[0].strategy_options : '{}';
+        var dcenters = JSON.parse(jsonOpts);
+        Object.keys(dcenters).forEach(function(dc) {
+            dcenters[dc] = parseInt(dcenters[dc]);
+        });
+        return dcenters;
+    });
+};
+
+/**
+ * ALTERs a Cassandra keyspace to match the replication policy, (a function of the
+ * configured datacenters, and the requested durability).
+ *
+ * @param  {string} domain;  the domain name
+ * @param  {string} table;   the table name
+ * @param  {object} options; query options from the initiating request
+ * @return {object} promise that resolves when complete
+ */
+DB.prototype._setReplication = function(domain, table, options) {
+    var cacheKey = JSON.stringify([domain,table]);
+    var keyspace = this.keyspaceNameCache[cacheKey] || this._keyspaceName(domain, table);
+    var cql = "ALTER KEYSPACE " + dbu.cassID(keyspace) + " WITH replication = " + this._createReplicationOptionsCQL(options);
+    this.log('warn/cassandra/replication', {
+        message: 'Updating replication for ' + keyspace,
+        replicas: this._replicationPolicy(options),
+        durability: options && options.durability || null
+    });
+    return this.client.execute_p(cql, [], {consistency: this.defaultConsistency});
+};
+
+/**
+ * Evaluates whether current keyspace replication matches the policy (a function of
+ * the configured datacenters, and the requested durability); Updates replication
+ * if necessary.
+ *
+ * NOTE: All this does is ALTER the underlying Cassandra keyspace, a repair (or
+ * cleanup) is is still necessary.
+ *
+ * @param  {string} domain;  the domain name
+ * @param  {string} table;   the table name
+ * @param  {object} options; query options from the initiating request
+ * @return {object} promise that resolves when complete
+ */
+DB.prototype._updateReplicationIfNecessary = function(domain, table, options) {
+    // returns true if two objects have matching keys and values
+    function matching(current, expected) {
+        if (Object.keys(current).length !== Object.keys(expected).length) {
+            return false;
+        }
+        return Object.keys(current).every(function(a) {
+            return current[a] === expected[a];
+        });
+    }
+
+    var self = this;
+    return self._getReplication(domain, table)
+    .then(function(current) {
+        if (!matching(current, self._replicationPolicy(options))) {
+            return self._setReplication(domain, table, options);
+        }
+        return P.resolve();
     });
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,13 +8,26 @@ var DB = require('./db');
 
 P.promisifyAll(cass, { suffix: '_p' });
 
+function validateAndNormalizeDcConf (conf) {
+    // Default to 'datacenter1'
+    if (!conf.localDc) { conf.localDc = 'datacenter1'; }
+    if (!conf.datacenters) { conf.datacenters = ['datacenter1']; }
+    if (!(conf.datacenters instanceof Array)) {
+        throw new Error('invalid datacenters configuration (not an array)');
+    }
+    if (conf.datacenters.indexOf(conf.localDc) < 0) {
+        throw new Error('localDc not in configured datacenters');
+    }
+}
+
 function makeClient (options) {
     var clientOpts = {};
     var conf = options.conf;
+    validateAndNormalizeDcConf(conf);
+
     clientOpts.keyspace = conf.keyspace || 'system';
     clientOpts.contactPoints = conf.hosts;
-    // Default to 'datacenter1'
-    if (!conf.localDc) { conf.localDc = 'datacenter1'; }
+
     // See http://www.datastax.com/drivers/nodejs/2.0/module-policies_loadBalancing-DCAwareRoundRobinPolicy.html
     clientOpts.policies = {
         loadBalancing: new loadBalancing.TokenAwarePolicy(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.7.14",
+  "version": "0.8.0",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.1.2",

--- a/test/functional/replication.js
+++ b/test/functional/replication.js
@@ -1,0 +1,74 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var assert = require('assert');
+var dbu = require('../../lib/dbutils');
+var fs = require('fs');
+var makeClient = require('../../lib/index');
+var yaml = require('js-yaml');
+
+var testTable0 = {
+    table: 'replicationTest',
+    attributes: {
+        title: 'string',
+        rev: 'int',
+        tid: 'timeuuid',
+        comment: 'string',
+        author: 'string'
+    },
+    index: [
+        { attribute: 'title', type: 'hash' },
+        { attribute: 'rev', type: 'range', order: 'desc' },
+        { attribute: 'tid', type: 'range', order: 'desc' }
+    ],
+};
+
+describe('Table creation', function() {
+    var db;
+    before(function() {
+        return makeClient({
+            log: function(level, info) {
+                if (!/^info|warn|verbose|debug|trace/.test(level)) {
+                    console.log(level, info);
+                }
+            },
+            conf: yaml.safeLoad(fs.readFileSync(__dirname + '/../utils/test_client.conf.yaml'))
+        })
+        .then(function(newDb) {
+            db = newDb;
+        })
+        .then(function() {
+            return db.createTable('restbase.cassandra.test.local', testTable0);
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 201);
+        });
+    });
+    after(function() {
+        db.dropTable('restbase.cassandra.test.local', testTable0.table);
+    });
+
+    it('updates Cassandra replication', function() {
+        return db._getReplication('restbase.cassandra.test.local', testTable0.table)
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.strictEqual(Object.keys(response).length, 1, 'incorrect number of results');
+
+            // Add one datacenter, and update.
+            db.conf.datacenters.push('new_dc');
+            return db._updateReplicationIfNecessary('restbase.cassandra.test.local', testTable0.table);
+        })
+        .then(function() {
+            return db._getReplication('restbase.cassandra.test.local', testTable0.table);
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.strictEqual(Object.keys(response).length, 2, 'incorrect number of results');
+            assert.ok(response.new_dc, 'additional datacenter not present');
+            assert.strictEqual(response.new_dc, 3, 'incorrect replica count');
+        });
+    });
+});

--- a/test/functional/replication.js
+++ b/test/functional/replication.js
@@ -30,7 +30,7 @@ describe('Table creation', function() {
     before(function() {
         return makeClient({
             log: function(level, info) {
-                if (!/^info|warn|verbose|debug|trace/.test(level)) {
+                if (/^error|fatal/.test(level)) {
                     console.log(level, info);
                 }
             },
@@ -38,8 +38,6 @@ describe('Table creation', function() {
         })
         .then(function(newDb) {
             db = newDb;
-        })
-        .then(function() {
             return db.createTable('restbase.cassandra.test.local', testTable0);
         })
         .then(function(response) {

--- a/test/utils/test_client.conf.yaml
+++ b/test/utils/test_client.conf.yaml
@@ -5,6 +5,9 @@ keyspace: system
 username: cassandra
 password: cassandra
 defaultConsistency: one
+localDc: datacenter1
+datacenters:
+ - datacenter1
 salt_key: secret
 maxLimit: 250
 storage_groups:


### PR DESCRIPTION
In `DB#createTable`, validate that current keyspace replication meets requirements (based on the list of datacenters from module configuration, and any durability options in the request), and adjust if necessary.

Bug: https://phabricator.wikimedia.org/T108613