### PR TITLE
Added support for static column additions

### DIFF
--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -50,6 +50,7 @@ function Attributes(parentMigrator, current, proposed) {
     this.log = parentMigrator.db.log;
     this.table = dbu.cassID(parentMigrator.req.keyspace)+'.'+dbu.cassID(parentMigrator.req.columnfamily);
     this.consistency = parentMigrator.req.consistency;
+    this.proposedSchema = parentMigrator.proposed;
     this.current = current;
     this.proposed = proposed;
 
@@ -76,7 +77,11 @@ Attributes.prototype._colType = function(col) {
 };
 
 Attributes.prototype._alterTableAdd = function(col) {
-    return this._alterTable()+' ADD '+dbu.cassID(col)+' '+this._colType(col);
+    var cql = this._alterTable()+' ADD '+dbu.cassID(col)+' '+this._colType(col);
+    if (this.proposedSchema.index && this.proposedSchema.staticKeyMap[col]) {
+        cql += ' static';
+    }
+    return cql;
 };
 
 Attributes.prototype._alterTableDrop = function(col) {
@@ -88,7 +93,7 @@ Attributes.prototype.migrate = function() {
     return P.each(self.addColumns, function(col) {
         self.log('warn/schemaMigration/attributes', {
             message: 'adding column' + col,
-            column: col,
+            column: col
         });
         var cql = self._alterTableAdd(col);
         return self.client.execute_p(cql, [], { consistency: self.consistency })
@@ -105,7 +110,7 @@ Attributes.prototype.migrate = function() {
         return P.each(self.delColumns, function(col) {
             self.log('warn/schemaMigration/attributes', {
                 message: 'dropping column ' + col,
-                column: col,
+                column: col
             });
             var cql = self._alterTableDrop(col);
             return self.client.execute_p(cql, [], { consistency: self.consistency })
@@ -123,10 +128,56 @@ Attributes.prototype.migrate = function() {
  * Index definition migrations
  */
 function Index(parentMigrator, current, proposed) {
-    Unsupported.call(this, 'index', current, proposed);
+    var self = this;
+    self.current = current;
+    self.proposed = proposed;
+    self.currentSchema = parentMigrator.current;
+    self.proposedSchema = parentMigrator.proposed;
+
+    self.addIndex = proposed.filter(function(x) { return !self._hasSameIndex(self.current, x); });
+    self.delIndex = current.filter(function(x) { return !self._hasSameIndex(self.proposed, x); });
+
+    self.alteredColumns = [];
+
+    // If index added and the column existed previously, need to remove it and add back to change index.
+    // Not supported.
+    self.addIndex.forEach(function(index) {
+        if (self.currentSchema.attributes[index.attribute]) {
+            self.alteredColumns.push(index.attribute);
+        }
+    });
+
+    // If index deleted the column is not deleted, need to remove it and add back to change index.
+    // Not supported.
+    self.delIndex.forEach(function(index) {
+        if (self.proposedSchema.attributes[index.attribute]) {
+            self.alteredColumns.push(index.attribute);
+        }
+    });
 }
 
-util.inherits(Index, Unsupported);
+Index.prototype.validate = function() {
+    var self = this;
+    if (self.addIndex.some(function(index) { return index.type !== 'static'; })
+            || self.delIndex.some(function(index) { return index.type !== 'static'; })) {
+        throw new Error('Only static index additions and removals supported');
+    }
+    if (self.alteredColumns.length > 0) {
+        throw new Error('Changing index on existing column not supported');
+    }
+};
+
+Index.prototype._hasSameIndex = function(indexes, proposedIndex) {
+    return indexes.some(function(idx) {
+        return idx.attribute === proposedIndex.attribute
+                    && idx.type === proposedIndex.type
+                    && idx.order === proposedIndex.order;
+    });
+};
+
+Index.prototype.migrate = function() {
+};
+
 
 /**
  * Secondary index definition migrations


### PR DESCRIPTION
For page-related information we would need to be able to add static columns to the schema. This PR adds this capability to Cassandra and SQLite.

This PR depends on tests in https://github.com/wikimedia/restbase-mod-table-spec/pull/14