### PR TITLE
Use Travis' new services stanza

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ node_js:
     - "0.12"
     - "iojs"
 
-before_install:
-  - sudo sh -c "echo 'JVM_OPTS=\"\${JVM_OPTS} -Djava.net.preferIPv4Stack=false\"' >> /usr/local/cassandra/conf/cassandra-env.sh"
-  - sudo service cassandra start
-
-before_script:
-  - sleep 5
+services:
+  - cassandra
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
     - "0.12"
     - "iojs"
 
+sudo: false
 services:
   - cassandra
 


### PR DESCRIPTION
Travis now supports starting up services with the 'services' stanza. This lets
us avoid using sudo & thus use the container infrastructure. As a result, our
tests should run faster. It also simplifies our .travis.yml slightly.