### PR TITLE
Normalize stored schemas before hashing

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -82,6 +82,7 @@ DB.prototype._makeInternalRequest = function (domain, table, query, consistency)
                 // internal _getRaw(), which doesn't apply transforms.
                 var schema = JSON.parse(res.items[0].value);
                 self.keyspaceNameCache[cacheKey] = req.keyspace;
+                schema = dbu.validateAndNormalizeSchema(schema);
                 self.schemaCache[cacheKey] = req.schema = dbu.makeSchemaInfo(schema);
                 self.keyspaceSchemaCache[req.keyspace] = req.schema;
             }
@@ -734,7 +735,7 @@ DB.prototype.createTable = function (domain, query) {
                         }
                     });
                 }
-                
+
                 migrationPromise = self._migrateBackend(req, currentSchemaInfo, newSchemaInfo);
             }
 


### PR DESCRIPTION
In 7fd61430a8cf50 the restbase-mod-table-spec module gained the ability to
sort index keys logically. When applied to new schemas only, this caused a
hash mis-match and thus an apparent schema change, which in turn caused
RESTBase to fail to start. Because of another issue in the service runner
logging code the reason for the start-up failure wasn't immediately clear (see
https://github.com/wikimedia/service-runner/pull/46). With that patch applied,
the failure revealed itself as
https://gist.github.com/gwicke/0a4bd4a1e8635df2aa28.

This patch applies the schema normalization to both stored and new schemas,
which eliminates the cause of the hash mis-match. With this applied, RESTBase
starts up successfully in staging. A similar patch needs to be applied in the
sqlite backend.