### PR TITLE
Added support for secondary index removal

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -889,7 +889,7 @@ DB.prototype._createTable = function (req, schema, columnfamily) {
         Object.keys(schema.secondaryIndexes).forEach(function(idx) {
             var indexSchema = schema.secondaryIndexes[idx];
             tasks = tasks.then(function() {
-                return self._createTable(req, indexSchema, 'idx_' + idx +"_ever");
+                return self._createTable(req, indexSchema, dbu.secondaryIndexTableName(idx));
             });
         });
     }

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -940,4 +940,8 @@ dbu.getTableCompressionCQL = function(compressions) {
     return '';
 };
 
+dbu.secondaryIndexTableName = function(idx) {
+    return 'idx_' + idx + '_ever';
+};
+
 module.exports = dbu;

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -208,10 +208,10 @@ function SecondaryIndexes(parentMigrator, current, proposed) {
 SecondaryIndexes.prototype.validate = function() {
     var self = this;
     if (self.addedIndexes.length > 0) {
-        throw new Error('Secondary index addition not supported');
+        throw new Error('Adding secondary indices is not supported');
     }
     if (self.changedIndexes.length > 0) {
-        throw new Error('Secondary index changing not supported');
+        throw new Error('Altering of secondary indices is not supported');
     }
 };
 
@@ -219,7 +219,7 @@ SecondaryIndexes.prototype.migrate = function() {
     var self = this;
     return self.deletedIndexes.forEach(function(indexName) {
         self.log('warn/schemaMigration/secondaryIndexes', {
-            message: 'adding column' + indexName,
+            message: 'deleting secondary index ' + indexName,
             index: indexName
         });
         var cql = self._removeIndexTable(indexName);

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -3,6 +3,7 @@
 var dbu = require('./dbutils');
 var P = require('bluebird');
 var util = require('util');
+var stringify = require('json-stable-stringify');
 
 
 /**
@@ -183,10 +184,57 @@ Index.prototype.migrate = function() {
  * Secondary index definition migrations
  */
 function SecondaryIndexes(parentMigrator, current, proposed) {
-    Unsupported.call(this, 'secondaryIndexes', current, proposed);
+    var self = this;
+    this.client = parentMigrator.db.client;
+    this.log = parentMigrator.db.log;
+    this.keyspace = dbu.cassID(parentMigrator.req.keyspace);
+    this.consistency = parentMigrator.req.consistency;
+
+    self.addedIndexes = [];
+    self.deletedIndexes = [];
+    self.changedIndexes = [];
+
+    new Set(Object.keys(current).concat(Object.keys(proposed))).forEach(function(indexName) {
+        if (!proposed[indexName]) {
+            self.deletedIndexes.push(indexName);
+        } else if (!current[indexName]) {
+            self.addedIndexes.push(indexName);
+        } else if (!self._isEqual(current[indexName], proposed[indexName])) {
+            self.changedIndexes.push(indexName);
+        }
+    });
 }
 
-util.inherits(SecondaryIndexes, Unsupported);
+SecondaryIndexes.prototype.validate = function() {
+    var self = this;
+    if (self.addedIndexes.length > 0) {
+        throw new Error('Secondary index addition not supported');
+    }
+    if (self.changedIndexes.length > 0) {
+        throw new Error('Secondary index changing not supported');
+    }
+};
+
+SecondaryIndexes.prototype.migrate = function() {
+    var self = this;
+    return self.deletedIndexes.forEach(function(indexName) {
+        self.log('warn/schemaMigration/secondaryIndexes', {
+            message: 'adding column' + indexName,
+            index: indexName
+        });
+        var cql = self._removeIndexTable(indexName);
+        return self.client.execute_p(cql, [], { consistency: self.consistency });
+    });
+};
+
+SecondaryIndexes.prototype._isEqual = function(currentIndex, proposedIndex) {
+    return stringify(currentIndex) === stringify(proposedIndex);
+};
+
+SecondaryIndexes.prototype._removeIndexTable = function(indexName) {
+    var self = this;
+    return 'drop table ' + self.keyspace + '.' + dbu.cassID(dbu.secondaryIndexTableName(indexName));
+};
 
 /**
  * Revision retention policy definiation migrations

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.1.2",


### PR DESCRIPTION
There was an idea to drop a by_ns secondary index, this adds a test for this feature in backends.

I'm wondering, if we should actually drop the table, or just store an updated schema? I'd better alter this PR and do the latter, to have 100% protection agains data corruption. And the tables could then be deleted manually. What do you think?

Bug: https://phabricator.wikimedia.org/T111959