### PR TITLE
Use `localOne` as default

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -16,7 +16,7 @@ function DB (client, options) {
     this.log = options.log;
 
     this.defaultConsistency = cass.types.consistencies[this.conf.defaultConsistency]
-        || cass.types.consistencies.one;
+        || cass.types.consistencies.localOne;
 
     // cassandra client
     this.client = client;
@@ -553,7 +553,7 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
         return P.resolve();
     }
 
-    var consistency = cass.types.consistencies.one;
+    var consistency = cass.types.consistencies.localOne;
     var tidKey = schema.tid;
 
     // Build a new request for the main data table

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -112,7 +112,7 @@ IndexRebuilder.prototype.handleRow = function (row) {
         var queryObj = dbu.buildPutQuery(idxReq, true);
         queries.push(
             self.db.client.execute_p(queryObj.cql, queryObj.params,
-                { consistency: cass.types.consistencies.one, prepare: true })
+                { consistency: cass.types.consistencies.localOne, prepare: true })
             .catch(function(e) {
                 self.db.log('error/table/cassandra/secondaryIndexUpdate', e);
             })
@@ -134,7 +134,7 @@ IndexRebuilder.prototype.handleRow = function (row) {
             var delQueryObj = dbu.buildPutQuery(delReq, true);
             queries.push(
                 this.db.client.execute_p(delQueryObj.cql, delQueryObj.params,
-                    { consistency: cass.types.consistencies.one, prepare: true })
+                    { consistency: cass.types.consistencies.localOne, prepare: true })
                 .catch(function(e) {
                     self.db.log('error/table/cassandra/secondaryIndexUpdate', e);
                 })


### PR DESCRIPTION
In the brave new world of multiple datacenters, when we say `one`, we
really mean `localOne`.

Bug: https://phabricator.wikimedia.org/T108613