### PR TITLE
Removed actual deleting of secondary index tables

### DIFF
--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -216,15 +216,8 @@ SecondaryIndexes.prototype.validate = function() {
 };
 
 SecondaryIndexes.prototype.migrate = function() {
-    var self = this;
-    return self.deletedIndexes.forEach(function(indexName) {
-        self.log('warn/schemaMigration/secondaryIndexes', {
-            message: 'deleting secondary index ' + indexName,
-            index: indexName
-        });
-        var cql = self._removeIndexTable(indexName);
-        return self.client.execute_p(cql, [], { consistency: self.consistency });
-    });
+    // Just update the metadata, actual table shouldn't be deleted
+    // to avoid index update failtures on other nodes.
 };
 
 SecondaryIndexes.prototype._isEqual = function(currentIndex, proposedIndex) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.1.2",


### PR DESCRIPTION
We cannot actually drop a secondary index tables during the deploy, as other nodes would fail to update the secondary index. So, just update the metadata for now.