### PR TITLE
Cache replication factor updates

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -34,6 +34,7 @@ DB.prototype._initSchemaCache = function() {
     this.schemaCache = {};
     this.keyspaceSchemaCache = {};
     this.keyspaceNameCache = {};
+    this.replicationUpdateCache = {};
 };
 
 /**
@@ -713,6 +714,15 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
     // (or both) of a backend or table schema migration occur, the new
     // JSON blob will be persisted.
 
+    if (!this.replicationUpdateCache[req.keyspace]) {
+        migrationPromise = self._updateReplicationIfNecessary(req.domain,
+                req.query.table, req.query.options)
+        .then(function() {
+            // Remember the successful replication check / update
+            self.replicationUpdateCache[req.keyspace] = true;
+        });
+    }
+
     // First carry out any back-end migration (if needed).
     if (currentSchemaInfo._backend_version !== newSchemaInfo._backend_version) {
         // A downgrade (unsupported)!
@@ -727,8 +737,10 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
                 }
             });
         }
-        
-        migrationPromise = self._migrateBackend(req, currentSchemaInfo, newSchemaInfo);
+
+        migrationPromise = migrationPromise.then(function() {
+            return self._migrateBackend(req, currentSchemaInfo, newSchemaInfo);
+        });
     }
 
     // Next carry out any table schema migration (if needed).
@@ -807,10 +819,7 @@ DB.prototype.createTable = function (domain, query) {
 
         if (currentSchemaInfo) {
             // Table already exists
-            return self._updateReplicationIfNecessary(domain, query.table, req.query.options)
-            .then(function() {
-                return self._migrateIfNecessary(req, currentSchemaInfo, newSchema, newSchemaInfo);
-            });
+            return self._migrateIfNecessary(req, currentSchemaInfo, newSchema, newSchemaInfo);
         }
 
         // Cassandra does not like concurrent keyspace creation. This is
@@ -1041,7 +1050,7 @@ DB.prototype.getTableSchema = function(domain, table) {
  * @param  {string} domain; the domain name
  * @param  {string} table;  the table name
  * @return {object} promise that yields an associative array of datacenters with
- *                  corresponding replication counts 
+ *                  corresponding replication counts
  */
 DB.prototype._getReplication = function(domain, table) {
     var cacheKey = JSON.stringify([domain,table]);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---recursive
+--recursive --timeout 5000


### PR DESCRIPTION
Only update replication factor checks / updates once per keyspace. Without
this caching and given a long list of domains, startup takes on the order of
minutes *per worker*.