### PR TITLE
DB schema caching & migration cleanup

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -725,11 +725,11 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
     // First, check if the replication factors need to be updated in line with
     // the cassandra module configuration.
     if (!this.replicationUpdateCache[req.keyspace]) {
+        self.log('info/cassandra/replication_update_check',
+                'Checking replication factor: ' + req.keyspace);
         migrationPromise = self._updateReplicationIfNecessary(req.domain,
                 req.query.table, req.query.options)
         .then(function() {
-            self.log('info/cassandra/replication_update_check',
-                    'Checking replication factor: ' + req.keyspace);
             // Remember the successful replication check / update
             self.replicationUpdateCache[req.keyspace] = true;
         });

--- a/lib/db.js
+++ b/lib/db.js
@@ -21,7 +21,7 @@ function DB (client, options) {
     // cassandra client
     this.client = client;
 
-    this._initSchemaCache();
+    this._initCaches();
 
     /* Process the array of storage groups declared in the config */
     this.storageGroups = this._buildStorageGroups(options.conf.storage_groups);
@@ -29,13 +29,15 @@ function DB (client, options) {
     this.storageGroupsCache = {};
 }
 
-DB.prototype._initSchemaCache = function() {
-    // cache keyspace -> schema
+DB.prototype._initCaches = function() {
+    // keyspace -> schema
     this.schemaCache = {};
-    this.keyspaceSchemaCache = {};
+    // JSON.stringify([domain, table]) -> keyspace
     this.keyspaceNameCache = {};
+    // keyspace -> boolean: replication factors checked / updated
     this.replicationUpdateCache = {};
 };
+
 
 /**
  * Set up internal request-related information and wrap it into an
@@ -44,66 +46,77 @@ DB.prototype._initSchemaCache = function() {
 DB.prototype._makeInternalRequest = function (domain, table, query, consistency) {
     var self = this;
     consistency = consistency || this.defaultConsistency;
-    if (query.consistency && query.consistency in {all:1, localQuorum:1}) {
+    if (query.consistency && query.consistency in {all:1, localOne: 1, localQuorum:1}) {
         consistency = cass.types.consistencies[query.consistency];
     }
-    var cacheKey = JSON.stringify([domain,table]);
+    var keyspace = this._keyspaceName(domain, table);
     var req = new InternalRequest({
         domain: domain,
         table: table,
-        keyspace: this.keyspaceNameCache[cacheKey]
-            || this._keyspaceName(domain, table),
+        keyspace: keyspace,
         query: query,
         consistency: consistency,
         columnfamily: 'data',
-        schema: this.schemaCache[cacheKey]
+        schema: this.schemaCache[keyspace]
     });
-    if (!req.schema) {
-        // Share the schema across domains that map to the same keyspace
-        req.schema = this.keyspaceSchemaCache[req.keyspace];
-    }
     if (req.schema) {
         return P.resolve(req);
     } else {
-        var schemaQuery = {
-            attributes: {
-                key: 'schema'
-            },
-            limit: 1
-        };
-        var schemaReq = req.extend({
-            query: schemaQuery,
-            columnfamily: 'meta',
-            schema: this.infoSchemaInfo
-        });
-        return this._getRaw(schemaReq)
-        .then(function(res) {
-            if (res.items.length) {
-                // Need to parse the JSON manually here as we are using the
-                // internal _getRaw(), which doesn't apply transforms.
-                var schema = JSON.parse(res.items[0].value);
-                self.keyspaceNameCache[cacheKey] = req.keyspace;
-                schema = dbu.validateAndNormalizeSchema(schema);
-                self.schemaCache[cacheKey] = req.schema = dbu.makeSchemaInfo(schema);
-                self.keyspaceSchemaCache[req.keyspace] = req.schema;
-            }
-            return req;
-        }, function(err) {
-            // Check if the keyspace & meta column family exists
-            return self.client.execute_p('SELECT columnfamily_name FROM '
-                + 'system.schema_columnfamilies WHERE keyspace_name=? '
-                + 'and columnfamily_name=?', [req.keyspace, 'meta'])
-            .then(function (res) {
-                if (res && res.rows.length === 0) {
+        return this._fetchSchema(req);
+    }
+};
+
+/**
+ * Fetch a logical table schema from <keyspace>.meta, key 'schema'.
+ * @param {InternalRequest} req
+ * @return {object} schema
+ */
+DB.prototype._fetchSchema = function(req) {
+    var self = this;
+
+    var schemaQuery = {
+        attributes: {
+            key: 'schema'
+        },
+        limit: 1
+    };
+    var schemaReq = req.extend({
+        query: schemaQuery,
+        columnfamily: 'meta',
+        schema: this.infoSchemaInfo
+    });
+    return this._getRaw(schemaReq)
+    .then(function(res) {
+        if (res.items.length) {
+            // Need to parse the JSON manually here as we are using the
+            // internal _getRaw(), which doesn't apply transforms.
+            var schema = JSON.parse(res.items[0].value);
+            schema = dbu.validateAndNormalizeSchema(schema);
+            self.schemaCache[req.keyspace] = req.schema = dbu.makeSchemaInfo(schema);
+        }
+        return req;
+    }, function(err) {
+        // Check if the keyspace & meta column family exists
+        return self.client.execute_p('SELECT columnfamily_name FROM '
+            + 'system.schema_columnfamilies WHERE keyspace_name=? '
+            + 'and columnfamily_name=?', [req.keyspace, 'meta'])
+        .then(function (res) {
+            if (res) {
+                if (res.rows.length === 0) {
                     // meta column family doesn't exist yet
                     return req;
-                } else {
-                    // re-throw error
-                    throw err;
+                } else if (res.rows.length === 1) {
+                    // Looks like the C* driver's schema cache was temporarily
+                    // out of date after a schema change. We found the schema
+                    // entry now, so retry the original schema request.
+                    return self._fetchSchema(req);
                 }
-            });
+            } else {
+                // re-throw error
+                throw err;
+            }
         });
-    }
+    });
 };
 
 /**
@@ -145,12 +158,20 @@ DB.prototype._buildStorageGroups = function (groups) {
  * @return {string} Valid Cassandra keyspace key
  */
 DB.prototype._keyspaceName = function (domain, table) {
+    var cacheKey = JSON.stringify([domain,table]);
+    var cachedName = this.keyspaceNameCache[cacheKey];
+    if (cachedName) {
+        return cachedName;
+    }
+
     var name = this._resolveStorageGroup(domain).name;
     var reversedName = name.toLowerCase().split('.').reverse().join('.');
     var prefix = dbu.makeValidKey(reversedName, Math.max(26, 48 - table.length - 3));
-    return prefix
+    var res = prefix
         // 6 chars _hash_ to prevent conflicts between domains & table names
         + '_T_' + dbu.makeValidKey(table, 48 - prefix.length - 3);
+    this.keyspaceNameCache[cacheKey] = res;
+    return res;
 };
 
 /**
@@ -718,6 +739,8 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
         migrationPromise = self._updateReplicationIfNecessary(req.domain,
                 req.query.table, req.query.options)
         .then(function() {
+            self.log('info/cassandra/replication_update_check',
+                    'Checking replication factor: ' + req.keyspace);
             // Remember the successful replication check / update
             self.replicationUpdateCache[req.keyspace] = true;
         });
@@ -725,6 +748,8 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
 
     // First carry out any back-end migration (if needed).
     if (currentSchemaInfo._backend_version !== newSchemaInfo._backend_version) {
+        self.log('info/cassandra/backend_version_mismatch',
+                'Backend version mismatch: ' + req.keyspace);
         // A downgrade (unsupported)!
         if (newSchemaInfo._backend_version < currentSchemaInfo._backend_version) {
             throw new dbu.HTTPError({
@@ -745,6 +770,9 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
 
     // Next carry out any table schema migration (if needed).
     if (currentSchemaInfo.hash !== newSchemaInfo.hash) {
+        self.log('info/cassandra/schema_hash_mismatch',
+                'Schema hash mismatch: ' + currentSchemaInfo.hash
+                + ' != ' + newSchemaInfo.hash);
         var migrator;
         try {
             migrator = new SchemaMigrator(
@@ -784,7 +812,7 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
             return self._put(putReq)
             .then(function() {
                 // Force a cache update on subsequent requests
-                self._initSchemaCache();
+                self.schemaCache[req.keyspace] = null;
                 return { status: 201 };
             })
             .catch(function(error) {
@@ -863,6 +891,9 @@ DB.prototype.createTable = function (domain, query) {
                 });
                 return self._put(putReq)
                 .then(function() {
+                    // No need to update replication settings for just-created
+                    // table.
+                    self.replicationUpdateCache[req.keyspace] = true;
                     return {
                         status: 201
                     };
@@ -1013,16 +1044,16 @@ DB.prototype._replicationPolicy = function(options) {
 
 DB.prototype.dropTable = function (domain, table) {
     var keyspace = this._keyspaceName(domain, table);
+    this.schemaCache[keyspace] = null;
     return this.client.execute_p('drop keyspace ' + cassID(keyspace), [],
             {consistency: this.defaultConsistency});
 };
 
 DB.prototype.getTableSchema = function(domain, table) {
-    var cacheKey = JSON.stringify([domain,table]);
     var req = new InternalRequest({
         domain: domain,
         table: table,
-        keyspace: this.keyspaceNameCache[cacheKey] || this._keyspaceName(domain, table),
+        keyspace: this._keyspaceName(domain, table),
         query: { attributes: { key: 'schema' }, limit: 1 },
         consistency: this.defaultConsistency,
         columnfamily: 'meta',
@@ -1053,8 +1084,7 @@ DB.prototype.getTableSchema = function(domain, table) {
  *                  corresponding replication counts
  */
 DB.prototype._getReplication = function(domain, table) {
-    var cacheKey = JSON.stringify([domain,table]);
-    var keyspace = this.keyspaceNameCache[cacheKey] || this._keyspaceName(domain, table);
+    var keyspace = this._keyspaceName(domain, table);
     var cql = "SELECT strategy_options FROM system.schema_keyspaces WHERE keyspace_name = '" + keyspace + "'";
     return this.client.execute_p(cql, [], {consistency: this.defaultConsistency})
     .then(function(res) {
@@ -1077,8 +1107,7 @@ DB.prototype._getReplication = function(domain, table) {
  * @return {object} promise that resolves when complete
  */
 DB.prototype._setReplication = function(domain, table, options) {
-    var cacheKey = JSON.stringify([domain,table]);
-    var keyspace = this.keyspaceNameCache[cacheKey] || this._keyspaceName(domain, table);
+    var keyspace = this._keyspaceName(domain, table);
     var cql = "ALTER KEYSPACE " + dbu.cassID(keyspace) + " WITH replication = " + this._createReplicationOptionsCQL(options);
     this.log('warn/cassandra/replication', {
         message: 'Updating replication for ' + keyspace,
@@ -1118,7 +1147,6 @@ DB.prototype._updateReplicationIfNecessary = function(domain, table, options) {
         if (!matching(current, self._replicationPolicy(options))) {
             return self._setReplication(domain, table, options);
         }
-        return P.resolve();
     });
 };
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -788,7 +788,8 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
                     type: 'bad_request',
                     title: 'The table already exists, and it cannot be upgraded to the requested schema (' + error + ').',
                     keyspace: req.keyspace,
-                    schema: newSchema
+                    schema: newSchema,
+                    stack: error.stack,
                 }
             });
         }

--- a/lib/db.js
+++ b/lib/db.js
@@ -719,7 +719,21 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
     var self = this;
 
     var migrationPromise = P.resolve();
-    var emptyPromise = migrationPromise;
+    var noopPromise = migrationPromise;
+    var schemaWriteNeeded = false;
+
+    // First, check if the replication factors need to be updated in line with
+    // the cassandra module configuration.
+    if (!this.replicationUpdateCache[req.keyspace]) {
+        migrationPromise = self._updateReplicationIfNecessary(req.domain,
+                req.query.table, req.query.options)
+        .then(function() {
+            self.log('info/cassandra/replication_update_check',
+                    'Checking replication factor: ' + req.keyspace);
+            // Remember the successful replication check / update
+            self.replicationUpdateCache[req.keyspace] = true;
+        });
+    }
 
     // The _backend_version attribute is excluded from the schema hash
     // calculation so that we can evaluate these different classes of
@@ -732,18 +746,7 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
     // (or both) of a backend or table schema migration occur, the new
     // JSON blob will be persisted.
 
-    if (!this.replicationUpdateCache[req.keyspace]) {
-        migrationPromise = self._updateReplicationIfNecessary(req.domain,
-                req.query.table, req.query.options)
-        .then(function() {
-            self.log('info/cassandra/replication_update_check',
-                    'Checking replication factor: ' + req.keyspace);
-            // Remember the successful replication check / update
-            self.replicationUpdateCache[req.keyspace] = true;
-        });
-    }
-
-    // First carry out any back-end migration (if needed).
+    // Then, carry out any back-end migration (if needed).
     if (currentSchemaInfo._backend_version !== newSchemaInfo._backend_version) {
         self.log('info/cassandra/backend_version_mismatch',
                 'Backend version mismatch: ' + req.keyspace);
@@ -763,6 +766,7 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
         migrationPromise = migrationPromise.then(function() {
             return self._migrateBackend(req, currentSchemaInfo, newSchemaInfo);
         });
+        schemaWriteNeeded = true;
     }
 
     // Next carry out any table schema migration (if needed).
@@ -791,11 +795,14 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
             });
         }
         migrationPromise = migrationPromise.then(migrator.migrate.bind(migrator));
+        schemaWriteNeeded = true;
     }
 
-    // Finally, if there are any migrations, apply them and persist.
-    if (migrationPromise !== emptyPromise) {
-        return migrationPromise
+    // Finally, update the stored schema if it changed.
+    if (schemaWriteNeeded) {
+        // Force a cache update on subsequent requests
+        self.schemaCache[req.keyspace] = null;
+        migrationPromise = migrationPromise
         .then(function() {
             var putReq = req.extend({
                 columnfamily: 'meta',
@@ -807,16 +814,20 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
                     }
                 }
             });
-            return self._put(putReq)
-            .then(function() {
-                // Force a cache update on subsequent requests
-                self.schemaCache[req.keyspace] = null;
-                return { status: 201 };
-            })
-            .catch(function(error) {
-                self.log('error/cassandra/table_update', error);
-                throw error;
-            });
+            return self._put(putReq);
+        });
+    }
+
+    if (migrationPromise !== noopPromise) {
+        return migrationPromise
+        .then(function() {
+            return {
+                status: 201
+            };
+        })
+        .catch(function(error) {
+            self.log('error/cassandra/table_update', error);
+            throw error;
         });
     } else {
         return {

--- a/lib/db.js
+++ b/lib/db.js
@@ -96,26 +96,23 @@ DB.prototype._fetchSchema = function(req) {
         }
         return req;
     }, function(err) {
-        // Check if the keyspace & meta column family exists
-        return self.client.execute_p('SELECT columnfamily_name FROM '
-            + 'system.schema_columnfamilies WHERE keyspace_name=? '
-            + 'and columnfamily_name=?', [req.keyspace, 'meta'])
-        .then(function (res) {
-            if (res) {
-                if (res.rows.length === 0) {
+        if (/^Keyspace .* does not exist$/.test(err.message)) {
+            return req;
+        } else {
+            // Check if the meta column family exists
+            return self.client.execute_p('SELECT columnfamily_name FROM '
+                + 'system.schema_columnfamilies WHERE keyspace_name=? '
+                + 'and columnfamily_name=?', [req.keyspace, 'meta'])
+            .then(function (res) {
+                if (res && res.rows.length === 0) {
                     // meta column family doesn't exist yet
                     return req;
-                } else if (res.rows.length === 1) {
-                    // Looks like the C* driver's schema cache was temporarily
-                    // out of date after a schema change. We found the schema
-                    // entry now, so retry the original schema request.
-                    return self._fetchSchema(req);
+                } else {
+                    // re-throw error
+                    throw err;
                 }
-            } else {
-                // re-throw error
-                throw err;
-            }
-        });
+            });
+        }
     });
 };
 

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -7,7 +7,7 @@ var extend = require('extend');
 var cass = require('cassandra-driver');
 var util = require('util');
 var P = require('bluebird');
-var stringify = require('json-stable-stringify');
+var stable_stringify = require('json-stable-stringify');
 var validator = require('restbase-mod-table-spec').validator;
 
 /*
@@ -113,10 +113,12 @@ dbu.makeValidKey = function makeValidKey (key, length) {
  * @return {string} the schema serialized to string
  */
 dbu.makeSchemaHash = function makeSchemaHash(schema) {
-    var clone = Object.assign({}, schema);
+    var _backend_version = schema._backend_version;
     // eliminate _backend_version from hash comparisons (see: DB#createTable)
-    delete clone._backend_version;
-    return stringify(clone);
+    schema._backend_version = undefined;
+    var hash = stable_stringify(schema);
+    schema._backend_version = _backend_version;
+    return hash;
 };
 
 /**

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -16,7 +16,7 @@ function Unsupported(attr, current, proposed) {
 }
 
 Unsupported.prototype.validate = function() {
-    if (dbu.makeSchemaHash(this.current) !== dbu.makeSchemaHash(this.proposed)) {
+    if (stringify(this.current) !== stringify(this.proposed)) {
         throw new Error(this.attr + ' attribute migrations are unsupported');
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.1.2",


### PR DESCRIPTION
- Remove the keyspaceSchemaCache, and make the schemaCache purely
  keyspace-based. Document caches better.
- Encapsulate the keyspaceSchemaCache handling in _keyspaceName().
- Don't wipe all caches when creating a new table, or migrating a schema.
- Retry transient errors in schema retrieval when a second request indicates
  that the keyspace and table now exists.
- Improve logging in schema migrations.
- Avoid allocations and delete in schema hashing code.