### PR TITLE
Added a check for non-existing columns on insert

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -468,6 +468,12 @@ DB.prototype._put = function(req) {
     }
     var schema = req.schema;
     var query = req.query;
+    var missingColumn = Object.keys(query.attributes).find(function(attrName) {
+        return !schema.attributes[attrName];
+    });
+    if (missingColumn) {
+        throw new Error('Unknown attribute ' + missingColumn);
+    }
 
     var tid = query.attributes[schema.tid];
     if (!tid) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -501,7 +501,7 @@ DB.prototype._put = function(req) {
             });
             idxReq.query = Object.assign({}, idxReq.query);
             idxReq.query.attributes = newQueryAttributes;
-            
+
             batch.push(dbu.buildPutQuery(idxReq));
         }
     }

--- a/lib/db.js
+++ b/lib/db.js
@@ -468,12 +468,6 @@ DB.prototype._put = function(req) {
     }
     var schema = req.schema;
     var query = req.query;
-    var missingColumn = Object.keys(query.attributes).find(function(attrName) {
-        return !schema.attributes[attrName];
-    });
-    if (missingColumn) {
-        throw new Error('Unknown attribute ' + missingColumn);
-    }
 
     var tid = query.attributes[schema.tid];
     if (!tid) {
@@ -497,6 +491,17 @@ DB.prototype._put = function(req) {
                 columnfamily: dbu.idxColumnFamily(idx),
                 schema: secondarySchema
             });
+
+            // Don't send over all attributes, only those existing in a secondary index table
+            var newQueryAttributes = {};
+            Object.keys(idxReq.query.attributes).forEach(function(attrName) {
+                if (secondarySchema.attributes[attrName]) {
+                    newQueryAttributes[attrName] = idxReq.query.attributes[attrName];
+                }
+            });
+            idxReq.query = Object.assign({}, idxReq.query);
+            idxReq.query.attributes = newQueryAttributes;
+            
             batch.push(dbu.buildPutQuery(idxReq));
         }
     }

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -704,7 +704,7 @@ dbu.buildPutQuery = function(req, noConvert) {
                 params.push(val);
             }
             placeholders.push('?');
-        } else if (!/^_ttl.*/.test(key)) { // Allow TTL fields not in the schema
+        } else if (!/^_ttl.*/.test(key) && !schema.attributes[key]) { // Allow TTL fields not in the schema
             throw new Error('Unknown attribute ' + key);
         }
     });

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -704,6 +704,8 @@ dbu.buildPutQuery = function(req, noConvert) {
                 params.push(val);
             }
             placeholders.push('?');
+        } else if (!/^_ttl.*/.test(key)) { // Allow TTL fields not in the schema
+            throw new Error('Unknown attribute ' + key);
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.1.2",


### PR DESCRIPTION
When we try to insert a field that's not in the schema, cassandra silently ignores that and SQLite is throwing a non-descriptive error. However, extra fields clearly indicate a bug in the client - either on table schema, or on a query, so we need to fail-fast and throw an error.