### PR TITLE
Implemented support for a revisionRetentionPolicy with 0 count

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -644,10 +644,16 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
     // Query for a window that includes 1 newer record (if any exists), and up
     // to 'limit' later records.  Run the list of update handlers across each
     // matching row, in descending order.
-    return self._getRaw(newerRebuildRequest)
+    return self._getRaw(newerRebuildRequest, { withTTLs: true })
     .then(function(res) {    // Query for one record previous
         return P.try(function() {
-            return P.each(res.items.reverse(), indexRebuilder.handleRow.bind(indexRebuilder));
+            return P.each(res.items.reverse(), indexRebuilder.handleRow.bind(indexRebuilder))
+            .then(function() {
+                if (res.items.length) {
+                    // Send just added data to policyManager to handle cases with 0 count
+                    return policyManager.handleRow(res.items[0]);
+                }
+            });
         });
     })
     .catch(function(e) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -807,7 +807,7 @@ dbu.buildGetQuery = function(req, options) {
     }
 
     var projCQL = Object.keys(schema.attributes).map(dbu.cassID).join(',');
-    var projAttrs = schema.attributes;
+    var projAttrs = Object.keys(schema.attributes);
 
     if (query.proj) {
         if (Array.isArray(query.proj)) {
@@ -822,7 +822,7 @@ dbu.buildGetQuery = function(req, options) {
     // Add TTL attributes for all non-index attributes
     if (options.withTTLs) {
         // Candidates for TTL are non-index, non-collection, attributes
-        var ttlCandidates = Object.keys(projAttrs).filter(
+        var ttlCandidates = projAttrs.filter(
             function(v) {
                 return !schema.iKeyMap[v] && !/^(set|map|list)<.*>$/.test(schema.attributes[v]);
             }

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -16,8 +16,6 @@ function RevisionPolicyManager(db, request, schema) {
     this.policy = schema.revisionRetentionPolicy;
     this.request = dbu.makeRawRequest(request, { ttl: this.policy.grace_ttl });
     this.noop = this.policy.type === 'all';
-    // The latest / just inserted row is not processed by the retentionPolicy,
-    // so start with count 1.
     this.count = 0;
     if (this.policy.type === 'interval') {
         var interval = this.policy.interval * 1000;

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -18,7 +18,7 @@ function RevisionPolicyManager(db, request, schema) {
     this.noop = this.policy.type === 'all';
     // The latest / just inserted row is not processed by the retentionPolicy,
     // so start with count 1.
-    this.count = 1;
+    this.count = 0;
     if (this.policy.type === 'interval') {
         var interval = this.policy.interval * 1000;
         var tidTime = this.request.query.timestamp;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "extend": "^2.0.0",
     "js-yaml": "^3.2.5",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "~0.0.5"
+    "restbase-mod-table-spec": "^0.0.9"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.1.2",


### PR DESCRIPTION
In cassandra we start looking at a `revisionRetentionPolicy` starting from a row just after the row we've just inserted. This needs to be updated to support policy with `count === 0`, that just set a graceTTL.

Also, there's been a bug in buldGetQuery - when `withTTLs` option was provided it failed with a 500 error.

SQLite module doesn't need updates, spec module is updated with a test.