### PR TITLE
Conf ver

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,6 +68,7 @@ While complete configuration of RESTBase is beyond the scope of this document, (
       type: npm
       options: # Passed to the module constructor
         conf:
+          version: 1
           hosts: [localhost]
           username: cassandra
           password: cassandra
@@ -78,6 +79,16 @@ While complete configuration of RESTBase is beyond the scope of this document, (
           storage_groups:
             - name: default.group.local
               domains: /./
+```
+
+### Version
+The version of this configuration.  Each edit of the module configuration must
+correpond to a new, unique version.
+
+*Note: Versions must be monotonically increasing.*
+
+```yaml
+    version: 1
 ```
 
 ### Hosts

--- a/lib/db.js
+++ b/lib/db.js
@@ -29,6 +29,10 @@ function DB (client, options) {
     this.storageGroups = this._buildStorageGroups(options.conf.storage_groups);
     /* The cache holding the already-resolved domain-to-group mappings */
     this.storageGroupsCache = {};
+
+    if (!this.conf.version) {
+        this.conf.version = dbu.DEFAULT_CONFIG_VERSION;
+    }
 }
 
 DB.prototype._initCaches = function() {
@@ -742,15 +746,35 @@ DB.prototype._migrateIfNecessary = function(req, currentSchemaInfo, newSchema, n
 
     // First, check if the replication factors need to be updated in line with
     // the cassandra module configuration.
-    if (!this.replicationUpdateCache[req.keyspace]) {
-        self.log('info/cassandra/replication_update_check',
-                'Checking replication factor: ' + req.keyspace);
-        migrationPromise = self._updateReplicationIfNecessary(req.domain,
-                req.query.table, req.query.options)
-        .then(function() {
-            // Remember the successful replication check / update
-            self.replicationUpdateCache[req.keyspace] = true;
-        });
+    if (currentSchemaInfo._config_version !== newSchemaInfo._config_version) {
+        self.log('warn/cassandra/configuration',
+                'configuration version differs from previously persisted for ' + req.keyspace + '('
+                    + newSchemaInfo._config_version + ' vs ' + currentSchemaInfo._config_version + ')');
+
+        if (newSchemaInfo._config_version < currentSchemaInfo._config_version) {
+            throw new dbu.HTTPError({
+                status: 400,
+                body: {
+                    type: 'bad_request',
+                    title: 'Unable to downgrade storage module configuration to version '+newSchemaInfo._config_version,
+                    keyspace: req.keyspace,
+                    schema: newSchema
+                }
+            });
+        }
+
+        schemaWriteNeeded = true;
+
+        if (!this.replicationUpdateCache[req.keyspace]) {
+            self.log('info/cassandra/replication_update_check',
+                    'Checking replication factor: ' + req.keyspace);
+            migrationPromise = self._updateReplicationIfNecessary(req.domain,
+                    req.query.table, req.query.options)
+            .then(function() {
+                // Remember the successful replication check / update
+                self.replicationUpdateCache[req.keyspace] = true;
+            });
+        }
     }
 
     // The _backend_version attribute is excluded from the schema hash
@@ -869,7 +893,7 @@ DB.prototype.createTable = function (domain, query) {
         var currentSchemaInfo = req.schema;
 
         // Validate and normalize the schema
-        var newSchema = dbu.validateAndNormalizeSchema(req.query);
+        var newSchema = dbu.validateAndNormalizeSchema(req.query, self.conf.version);
         var newSchemaInfo = dbu.makeSchemaInfo(newSchema);
 
         if (currentSchemaInfo) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -114,10 +114,13 @@ dbu.makeValidKey = function makeValidKey (key, length) {
  */
 dbu.makeSchemaHash = function makeSchemaHash(schema) {
     var _backend_version = schema._backend_version;
-    // eliminate _backend_version from hash comparisons (see: DB#createTable)
+    var _config_version = schema._config_version;
+    // eliminate private versions from hash comparisons (see: DB#createTable)
     schema._backend_version = undefined;
+    schema._config_version = undefined;
     var hash = stable_stringify(schema);
     schema._backend_version = _backend_version;
+    schema._config_version = _config_version;
     return hash;
 };
 
@@ -215,14 +218,19 @@ dbu.eachRow = function eachRow(client, query, params, options, handler) {
 dbu.DEFAULT_BACKEND_VERSION = 0;
 dbu.CURRENT_BACKEND_VERSION = 1;
 
+dbu.DEFAULT_CONFIG_VERSION = 0;    // Implicit module config version.
+
 /**
  * Wrapper for validator#validateAndNormalizeSchema (shipped in
  * restbase-m-t-spec). Ensures the presence of the private,
- * implementation-specific _backend_version schema attribute.
+ * implementation-specific version attributes.
  */
-dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
+dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema, configVer) {
     if (!schema._backend_version) {
         schema._backend_version = dbu.CURRENT_BACKEND_VERSION;
+    }
+    if (configVer) {
+        schema._config_version = configVer;
     }
     return validator.validateAndNormalizeSchema(schema);
 };
@@ -504,6 +512,10 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema, isMetaCF) {
 
     if (!psi._backend_version) {
         psi._backend_version = dbu.DEFAULT_BACKEND_VERSION;
+    }
+
+    if (!psi._config_version) {
+        psi._config_version = dbu.DEFAULT_CONFIG_VERSION;
     }
 
     // define a 'hash' string representation for the schema for quick schema

--- a/test/functional/config_migrations.js
+++ b/test/functional/config_migrations.js
@@ -1,0 +1,107 @@
+"use strict";
+
+// mocha defines to avoid JSHint breakage
+/* global describe, it, before, beforeEach, after, afterEach */
+
+var assert = require('assert');
+var dbu = require('../../lib/dbutils');
+var fs = require('fs');
+var makeClient = require('../../lib/index');
+var yaml = require('js-yaml');
+
+var testTable0 = {
+    table: 'config-versioning',
+    options: { durability: 'low' },
+    attributes: {
+        title: 'string',
+        rev: 'int',
+        tid: 'timeuuid',
+        comment: 'string',
+        author: 'string'
+    },
+    index: [
+        { attribute: 'title', type: 'hash' },
+        { attribute: 'rev', type: 'range', order: 'desc' },
+        { attribute: 'tid', type: 'range', order: 'desc' }
+    ],
+    secondaryIndexes: {
+        by_rev : [
+            { attribute: 'rev', type: 'hash' },
+            { attribute: 'tid', type: 'range', order: 'desc' },
+            { attribute: 'title', type: 'range', order: 'asc' },
+            { attribute: 'comment', type: 'proj' }
+        ]
+    }
+};
+
+describe('Configuration migration', function() {
+    var db;
+    before(function() {
+        return makeClient({
+            log: function(level, info) {
+                if (!/^info|warn|verbose|debug|trace/.test(level)) {
+                    console.log(level, info);
+                }
+            },
+            conf: yaml.safeLoad(fs.readFileSync(__dirname + '/../utils/test_client.conf.yaml'))
+        })
+        .then(function(newDb) {
+            db = newDb;
+        })
+        .then(function() {
+            return db.createTable('restbase.cassandra.test.local', testTable0);
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 201);
+        });
+    });
+    after(function() {
+        return db.dropTable('restbase.cassandra.test.local', testTable0.table);
+    });
+
+    it('migrates version', function() {
+        return db.getTableSchema('restbase.cassandra.test.local', testTable0.table)
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.schema.table, testTable0.table);
+            assert.deepEqual(response.schema._config_version, 1);
+
+            db.conf.version = 2;
+            return db.createTable('restbase.cassandra.test.local', testTable0);
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 201);
+
+            return db.getTableSchema('restbase.cassandra.test.local', testTable0.table);
+        })
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.schema.table, testTable0.table);
+            assert.deepEqual(response.schema._config_version, 2);
+        });
+    });
+
+    it('disallows decreasing versions', function() {
+        // Migrate version (from 1) to 2.
+        db.conf.version = 2;
+        return db.createTable('restbase.cassandra.test.local', testTable0)
+        .then(function(response) {
+            assert.ok(response, 'undefined response');
+            assert.deepEqual(response.status, 201);
+
+            // Attempt to downgrade version (from 2) to 1
+            db.conf.version = 1;
+            return db.createTable('restbase.cassandra.test.local', testTable0)
+            .then(function(response) {
+                // A successful response means a downgrade happened (this is wrong).
+                assert.fail(response, undefined, 'expected HTTPError exception');
+            })
+            .catch(function(error) {
+                // This is what we want, an HTTPError and status 400.
+                assert.deepEqual(error.status, 400);
+            });
+        });
+    });
+});

--- a/test/unit/delete.js
+++ b/test/unit/delete.js
@@ -55,6 +55,10 @@ describe('Delete', function() {
         });
     });
 
+    after(function() {
+        return db.dropTable('restbase.cassandra.test.local', 'simple-table');
+    });
+
     // TODO: move to functional tests when delete rest endpoint
     // is implemented and dependency from impl db can be removed
     it('deletes row', function() {

--- a/test/utils/test_client.conf.yaml
+++ b/test/utils/test_client.conf.yaml
@@ -1,4 +1,5 @@
 type: restbase-cassandra
+version: 1
 hosts:
   - localhost
 keyspace: system


### PR DESCRIPTION
Adds a version attribute to the module configuration, and persists it to the meta.value schema structure as a hash-excluded private attribute (`_config_version`).  Replication changes are conditional on a monotonically increasing configuration version.

Bug: https://phabricator.wikimedia.org/T76494