### PR TITLE
Support binary data wrapped in JSON

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -396,7 +396,15 @@ function toNumber() {
 }
 
 dbu.conversions = {
-    json: { write: JSON.stringify, read: JSON.parse },
+    json: {
+        write: JSON.stringify,
+        read: function(body) {
+            return JSON.parse(body, function(key, value) {
+                return ((value instanceof Object) && (value.type === 'Buffer'))
+                ? new Buffer(value.data) : value;
+            });
+        }
+    },
     decimal: { read: toString() },
     timestamp: {
         read: function (date) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.2.1",


### PR DESCRIPTION
For graphoid, we need to store binary PNG wrapped in JSON. Perfect solution would be to support BSON across all of our tools, but until that's implemented we could use this workaround ti wrap `Buffer` into an ordinary JSON.