### PR TITLE
Support update pattern hinting and option migrations

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -998,17 +998,13 @@ DB.prototype._createTable = function (req, schema, columnfamily) {
     cql += 'primary key (';
     cql += ['(' + hashBits.join(',') + ')'].concat(rangeBits).join(',') + '))';
 
-    // Default to leveled compaction strategy
-    cql += " WITH compaction = { 'class' : 'LeveledCompactionStrategy' }";
+    // Add options for compression & compaction
+    cql += " WITH " + dbu.getOptionCQL(schema.options || {});
 
     if (orderBits.length) {
         cql += ' and clustering order by ( ' + orderBits.join(',') + ' )';
     }
 
-    if (schema.options && schema.options.compression) {
-        // check if we support one of the desired ones
-        cql += dbu.getTableCompressionCQL(schema.options.compression);
-    }
     //console.log(cql);
 
     // TODO: If the table already exists, check that the schema actually

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -920,6 +920,51 @@ dbu.buildGetQuery = function(req, options) {
     return {cql: cql, params: params};
 };
 
+dbu.getOptionCQL = function(options) {
+    // Generate the CQL for each option
+    var cqlParts = [
+        dbu.getTableCompressionCQL(options),
+        dbu.getTableCompactionCQL(options),
+    ];
+
+    // Remove falsy parts & join the remainder.
+    return cqlParts.filter(Boolean).join(' and ');
+};
+
+var updateOptionMap = {
+    'write-once': "{ 'class' : 'SizeTieredCompactionStrategy', "
+        + "'tombstone_threshold': '0.02' }",
+    'random-update': "{ 'class' : 'LeveledCompactionStrategy' }",
+    'timeseries': "{ 'class': 'DateTieredCompactionStrategy', "
+        // Change base_time_seconds from 60s default to 45, for better
+        // alignment with two-day expiry (24 hour TTL + 24 hour
+        // gc_grace_seconds). See also:
+        // https://issues.apache.org/jira/browse/CASSANDRA-8417
+        + "'base_time_seconds': '45',"
+        // More aggressive tombstone collection. Changes from defaults:
+        // - Lowered tombstone_threshold from 0.2 to 0.02
+        // - Enabled unchecked_tombstone_compaction, which allows tombstone
+        // collection even if key ranges overlap with other sstables. See
+        // http://thread.gmane.org/gmane.comp.db.cassandra.devel/9753 and
+        // http://mail-archives.apache.org/mod_mbox/cassandra-commits/201405.mbox/%3C8eaf7fbf908a4e40a77bc26b69ac7867@git.apache.org%3E
+        + "'tombstone_threshold': '0.02', 'unchecked_tombstone_compaction': 'true' }"
+        // TODO: Calculate this based on the retention policy?
+        + " and gc_grace_seconds = 86400",
+};
+
+dbu.getTableCompactionCQL = function(options) {
+    var pattern = options.updates && options.updates.pattern;
+    if (!pattern) {
+        // Default to 'random-update'
+        pattern = 'random-update';
+    }
+
+    if (!updateOptionMap[pattern]) {
+        throw new Error('Invalid update pattern: ' + pattern);
+    } else {
+        return 'compaction = ' + updateOptionMap[pattern];
+    }
+};
 
 dbu.validCompressionAlgorithms = {
     lz4: 'LZ4Compressor',
@@ -936,14 +981,19 @@ dbu.validCompressionBlockSizes = {
     1024: 1
 };
 
-dbu.getTableCompressionCQL = function(compressions) {
+dbu.getTableCompressionCQL = function(options) {
+    if (!options.compression) {
+        return;
+    }
+    var compressions = options.compression;
+
     for (var i = 0; i < compressions.length; i++) {
         var option = compressions[i];
         if (option
                 && dbu.validCompressionAlgorithms[option.algorithm]
                 && dbu.validCompressionAlgorithms[option.algorithm].constructor === String
                 && dbu.validCompressionBlockSizes[option.block_size]) {
-            return " and compression = { 'sstable_compression' : '"
+            return "compression = { 'sstable_compression' : '"
                 + dbu.validCompressionAlgorithms[option.algorithm]
                 + "', 'chunk_length_kb' : " + option.block_size + " }";
         }

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -38,10 +38,32 @@ util.inherits(Table, Unsupported);
  * options object migration handler
  */
 function Options(parentMigrator, current, proposed) {
-    Unsupported.call(this, 'options', current, proposed);
+    this.current = current;
+    this.proposed = proposed;
+
+    this.client = parentMigrator.db.client;
+    this.log = parentMigrator.db.log;
+    this.table = dbu.cassID(parentMigrator.req.keyspace) + '.'
+        + dbu.cassID(parentMigrator.req.columnfamily);
+    this.consistency = parentMigrator.req.consistency;
+
+    this.optionsCQL = null;
 }
 
-util.inherits(Options, Unsupported);
+Options.prototype.validate = function() {
+    if (stringify(this.current) !== stringify(this.proposed)) {
+        // Try to generate the options CQL, which implicitly validates it.
+        this.optionsCQL = dbu.getOptionCQL(this.proposed);
+    }
+};
+
+Options.prototype.migrate = function() {
+    if (this.optionsCQL) {
+        var cql = 'ALTER TABLE ' + this.table + ' WITH ' + this.optionsCQL;
+        return this.client.execute_p(cql, [], { consistency: this.consistency });
+    }
+};
+
 
 /**
  * attributes object migration handler
@@ -230,7 +252,7 @@ SecondaryIndexes.prototype._removeIndexTable = function(indexName) {
 };
 
 /**
- * Revision retention policy definiation migrations
+ * Revision retention policy definition migrations
  */
 function RevisionRetentionPolicy(parentMigrator, current, proposed) {
     this.db = parentMigrator.db;


### PR DESCRIPTION
- Generalize option CQL generation in dbutils.
- Support hinting for the expected update pattern:
  ```
    updates: {
        pattern: 'random-update', // or 'write-once', 'timeseries'
    }
  ```
  This hint is then used to optimize storage parameters. In Cassandra, this
  influences the compaction strategy selection. In SQLite, this option is
  currently ignored.
- Add option migration support.