### PR TITLE
Support long type mapped to bigint

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -411,7 +411,7 @@ dbu.conversions = {
     timeuuid: { read: toString() },
     uuid: { read: toString() },
     long: {
-        read: function(val) { return val.toString(); },
+        read: toString(),
         write: function(val) { return Long.fromString(val); }
     }
 };

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -9,6 +9,7 @@ var util = require('util');
 var P = require('bluebird');
 var stable_stringify = require('json-stable-stringify');
 var validator = require('restbase-mod-table-spec').validator;
+var Long = require('cassandra-driver').types.Long;
 
 /*
  * Various static database utility methods
@@ -326,7 +327,9 @@ var schemaTypeToCQLTypeMap = {
     'timestamp': 'timestamp',
     'set<timestamp>': 'set<timestamp>',
     'json': 'text',
-    'set<json>': 'set<text>'
+    'set<json>': 'set<text>',
+    'long': 'bigint',
+    'set<long>': 'set<bigint>'
 };
 
 // Map a schema type to the corresponding CQL type
@@ -406,7 +409,11 @@ dbu.conversions = {
     blob: { write: encodeBlob },
     varint: { read: toNumber() },
     timeuuid: { read: toString() },
-    uuid: { read: toString() }
+    uuid: { read: toString() },
+    long: {
+        read: function(val) { return val.toString(); },
+        write: function(val) { return Long.fromString(val); }
+    }
 };
 
 /*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.2.1",


### PR DESCRIPTION
This PR adds mapping of `long` schema type to `bigint` cassandra type.
Clients supply longs as strings due to Javascript Number precision limitations.