### PR TITLE
Support custom _ttl attributes for individual rows

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -51,7 +51,7 @@ DB.prototype._makeInternalRequest = function (domain, table, query, consistency)
         consistency = cass.types.consistencies[query.consistency];
     }
     var keyspace = this._keyspaceName(domain, table);
-    var req = new InternalRequest({
+    var opts = {
         domain: domain,
         table: table,
         keyspace: keyspace,
@@ -59,7 +59,12 @@ DB.prototype._makeInternalRequest = function (domain, table, query, consistency)
         consistency: consistency,
         columnfamily: 'data',
         schema: this.schemaCache[keyspace]
-    });
+    };
+    if (query && query.attributes && query.attributes._ttl) {
+        opts.ttl = query.attributes._ttl;
+        delete query.attributes._ttl;
+    }
+    var req = new InternalRequest(opts);
     if (req.schema) {
         return P.resolve(req);
     } else {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.2.1",
@@ -9,7 +9,7 @@
     "extend": "^2.0.0",
     "js-yaml": "^3.2.5",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "^0.1.0"
+    "restbase-mod-table-spec": "^0.1.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "extend": "^2.0.0",
     "js-yaml": "^3.2.5",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "^0.1.1"
+    "restbase-mod-table-spec": "^0.1.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Setting `_ttl` was already supported in cassandra, just need to look if it was provided by an external request.