### PR TITLE
Version migration: Bug fix: Compare the versions, not the objects

### DIFF
--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -286,7 +286,7 @@ function Version(parentMigrator, current, proposed) {
 
 // versions must be monotonically increasing.
 Version.prototype.validate = function() {
-    if (this.current >= this.proposed) {
+    if (this.current.version >= this.proposed.version) {
         throw new Error('new version must be higher than previous');
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.2.1",


### PR DESCRIPTION
There was a bug in the Version migrator validation code, where instead of comparing only the versions of the current and proposed schemas, their entire objects were being compared, yielding an incorrect check.

Also, bump the version to v0.8.10