### PR TITLE
Hints: Check cassandra version before applying DTCS hint

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -29,6 +29,8 @@ function DB (client, options) {
     this.storageGroups = this._buildStorageGroups(options.conf.storage_groups);
     /* The cache holding the already-resolved domain-to-group mappings */
     this.storageGroupsCache = {};
+
+    this.cassandraVersion = this._getCassandraVersion();
 }
 
 DB.prototype._initCaches = function() {
@@ -39,7 +41,6 @@ DB.prototype._initCaches = function() {
     // keyspace -> boolean: replication factors checked / updated
     this.replicationUpdateCache = {};
 };
-
 
 /**
  * Set up internal request-related information and wrap it into an
@@ -97,7 +98,7 @@ DB.prototype._fetchSchema = function(req) {
             // Need to parse the JSON manually here as we are using the
             // internal _getRaw(), which doesn't apply transforms.
             var schema = JSON.parse(res.items[0].value);
-            schema = dbu.validateAndNormalizeSchema(schema, self);
+            schema = dbu.validateAndNormalizeSchema(schema);
             self.schemaCache[req.keyspace] = req.schema = dbu.makeSchemaInfo(schema);
         }
         return req;
@@ -874,7 +875,7 @@ DB.prototype.createTable = function (domain, query) {
         var currentSchemaInfo = req.schema;
 
         // Validate and normalize the schema
-        var newSchema = dbu.validateAndNormalizeSchema(req.query, self);
+        var newSchema = dbu.validateAndNormalizeSchema(req.query);
         var newSchemaInfo = dbu.makeSchemaInfo(newSchema);
 
         if (currentSchemaInfo) {
@@ -1012,7 +1013,7 @@ DB.prototype._createTable = function (req, schema, columnfamily) {
     cql += ['(' + hashBits.join(',') + ')'].concat(rangeBits).join(',') + '))';
 
     // Add options for compression & compaction
-    cql += " WITH " + dbu.getOptionCQL(schema.options || {});
+    cql += " WITH " + dbu.getOptionCQL(schema.options || {}, self);
 
     if (orderBits.length) {
         cql += ' and clustering order by ( ' + orderBits.join(',') + ' )';

--- a/lib/db.js
+++ b/lib/db.js
@@ -97,7 +97,7 @@ DB.prototype._fetchSchema = function(req) {
             // Need to parse the JSON manually here as we are using the
             // internal _getRaw(), which doesn't apply transforms.
             var schema = JSON.parse(res.items[0].value);
-            schema = dbu.validateAndNormalizeSchema(schema);
+            schema = dbu.validateAndNormalizeSchema(schema, self);
             self.schemaCache[req.keyspace] = req.schema = dbu.makeSchemaInfo(schema);
         }
         return req;
@@ -874,7 +874,7 @@ DB.prototype.createTable = function (domain, query) {
         var currentSchemaInfo = req.schema;
 
         // Validate and normalize the schema
-        var newSchema = dbu.validateAndNormalizeSchema(req.query);
+        var newSchema = dbu.validateAndNormalizeSchema(req.query, self);
         var newSchemaInfo = dbu.makeSchemaInfo(newSchema);
 
         if (currentSchemaInfo) {
@@ -948,6 +948,14 @@ DB.prototype.createTable = function (domain, query) {
 
         return doCreateTables();
     });
+};
+
+DB.prototype._getCassandraVersion = function() {
+    try {
+        return this.client.controlConnection.host.cassandraVersion;
+    } catch (e) {
+        this.log('error/cassandraVersion', e);
+    }
 };
 
 DB.prototype._createTable = function (req, schema, columnfamily) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -218,27 +218,16 @@ dbu.DEFAULT_BACKEND_VERSION = 0;
 dbu.CURRENT_BACKEND_VERSION = 1;
 
 /**
- * Wrapper for validator#validateAndNormalizeSchema (shipped in
- * restbase-m-t-spec). Ensures the presence of the private,
- * implementation-specific _backend_version schema attribute.
+ * Wrapper for validator#validateAndNormalizeSchema (shipped in restbase-m-t-spec).
+ * Ensures the presence of the private, implementation-specific _backend_version
+ * schema attribute.
+ *
+ * @param {Object} schema a schema to check
+ * @returns {Object} an updated schema object
  */
-dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema, db) {
+dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
     if (!schema._backend_version) {
         schema._backend_version = dbu.CURRENT_BACKEND_VERSION;
-    }
-    if (db) {
-        var pattern = schema.options
-                && schema.options.updates
-                && schema.options.updates.pattern;
-        var cassandraVersion = db._getCassandraVersion();
-        if (pattern === 'timeseries' && cassandraVersion && semver.valid(cassandraVersion)) {
-            // DTCS is supported starting from cassandra 2.0.11 or 2.1.1
-            if (!semver.satisfies(cassandraVersion, '>= 2.0.11 < 2.1.0 || >= 2.1.1')) {
-                schema.options.updates.pattern = 'random-update';
-                db.log('warn/updateHints', 'Ignoring "timeseries" update hint: ' +
-                    'not supported by cassandra v' + cassandraVersion);
-            }
-        }
     }
     return validator.validateAndNormalizeSchema(schema);
 };
@@ -942,11 +931,11 @@ dbu.buildGetQuery = function(req, options) {
     return {cql: cql, params: params};
 };
 
-dbu.getOptionCQL = function(options) {
+dbu.getOptionCQL = function(options, db) {
     // Generate the CQL for each option
     var cqlParts = [
         dbu.getTableCompressionCQL(options),
-        dbu.getTableCompactionCQL(options),
+        dbu.getTableCompactionCQL(options, db),
     ];
 
     // Remove falsy parts & join the remainder.
@@ -974,11 +963,20 @@ var updateOptionMap = {
         + " and gc_grace_seconds = 86400",
 };
 
-dbu.getTableCompactionCQL = function(options) {
+dbu.getTableCompactionCQL = function(options, db) {
     var pattern = options.updates && options.updates.pattern;
     if (!pattern) {
         // Default to 'random-update'
         pattern = 'random-update';
+    }
+
+    if (pattern === 'timeseries' && db.cassandraVersion && semver.valid(db.cassandraVersion)) {
+        // DTCS is supported starting from cassandra 2.0.11 or 2.1.1
+        if (!semver.satisfies(db.cassandraVersion, '>= 2.0.11 < 2.1.0 || >= 2.1.1')) {
+            pattern = 'random-update';
+            db.log('warn/updateHints', 'Ignoring "timeseries" update hint: ' +
+                'not supported by cassandra v' + db.cassandraVersion);
+        }
     }
 
     if (!updateOptionMap[pattern]) {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -10,6 +10,7 @@ var P = require('bluebird');
 var stable_stringify = require('json-stable-stringify');
 var validator = require('restbase-mod-table-spec').validator;
 var Long = require('cassandra-driver').types.Long;
+var semver = require('semver');
 
 /*
  * Various static database utility methods
@@ -221,9 +222,23 @@ dbu.CURRENT_BACKEND_VERSION = 1;
  * restbase-m-t-spec). Ensures the presence of the private,
  * implementation-specific _backend_version schema attribute.
  */
-dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema) {
+dbu.validateAndNormalizeSchema = function validateAndNormalizeSchema(schema, db) {
     if (!schema._backend_version) {
         schema._backend_version = dbu.CURRENT_BACKEND_VERSION;
+    }
+    if (db) {
+        var pattern = schema.options
+                && schema.options.updates
+                && schema.options.updates.pattern;
+        var cassandraVersion = db._getCassandraVersion();
+        if (pattern === 'timeseries' && cassandraVersion && semver.valid(cassandraVersion)) {
+            // DTCS is supported starting from cassandra 2.0.11 or 2.1.1
+            if (!semver.satisfies(cassandraVersion, '>= 2.0.11 < 2.1.0 || >= 2.1.1')) {
+                schema.options.updates.pattern = 'random-update';
+                db.log('warn/updateHints', 'Ignoring "timeseries" update hint: ' +
+                    'not supported by cassandra v' + cassandraVersion);
+            }
+        }
     }
     return validator.validateAndNormalizeSchema(schema);
 };

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -973,7 +973,7 @@ dbu.getTableCompactionCQL = function(options, db) {
     if (pattern === 'timeseries' && db.cassandraVersion && semver.valid(db.cassandraVersion)) {
         // DTCS is supported starting from cassandra 2.0.11 or 2.1.1
         if (!semver.satisfies(db.cassandraVersion, '>= 2.0.11 < 2.1.0 || >= 2.1.1')) {
-            pattern = 'random-update';
+            pattern = 'write-once';
             db.log('warn/updateHints', 'Ignoring "timeseries" update hint: ' +
                 'not supported by cassandra v' + db.cassandraVersion);
         }

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -41,6 +41,7 @@ function Options(parentMigrator, current, proposed) {
     this.current = current;
     this.proposed = proposed;
 
+    this.parent = parentMigrator;
     this.client = parentMigrator.db.client;
     this.log = parentMigrator.db.log;
     this.table = dbu.cassID(parentMigrator.req.keyspace) + '.'
@@ -53,7 +54,7 @@ function Options(parentMigrator, current, proposed) {
 Options.prototype.validate = function() {
     if (stringify(this.current) !== stringify(this.proposed)) {
         // Try to generate the options CQL, which implicitly validates it.
-        this.optionsCQL = dbu.getOptionCQL(this.proposed);
+        this.optionsCQL = dbu.getOptionCQL(this.proposed, this.parent);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "~2.2.1",
@@ -9,7 +9,8 @@
     "extend": "^2.0.0",
     "js-yaml": "^3.2.5",
     "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "^0.1.2"
+    "restbase-mod-table-spec": "^0.1.3",
+    "semver": "^5.0.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Travis has cassandra 2.0.9, which doesn't support DTCS, so before applying a `timeseries` update hint we need to check that cassandra supports it. Support was added in 2.0.11 and 2.1.1.