### PR TITLE
Fixed TTL revPolicy and removed support for individual rows ttl

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -54,7 +54,7 @@ DB.prototype._makeInternalRequest = function(domain, table, query, consistency) 
         consistency = cass.types.consistencies[query.consistency];
     }
     var keyspace = this._keyspaceName(domain, table);
-    var opts = {
+    var req = new InternalRequest({
         domain: domain,
         table: table,
         keyspace: keyspace,
@@ -62,12 +62,7 @@ DB.prototype._makeInternalRequest = function(domain, table, query, consistency) 
         consistency: consistency,
         columnfamily: 'data',
         schema: this.schemaCache[keyspace]
-    };
-    if (query && query.attributes && query.attributes._ttl) {
-        opts.ttl = query.attributes._ttl;
-        delete query.attributes._ttl;
-    }
-    var req = new InternalRequest(opts);
+    });
     if (req.schema) {
         return P.resolve(req);
     } else {
@@ -527,14 +522,11 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
         attributes: {},
     };
 
-    var newerProj = ['_del'];
-
     // Narrow down the update to the original request's primary key. If
     // that's empty, the entire index (within the numerical limits) will be updated.
     schema.iKeys.forEach(function(att) {
         if (att !== tidKey) {
             dataQuery.attributes[att] = query.attributes[att];
-            newerProj.push(att);
         }
     });
 
@@ -545,15 +537,11 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
         Object.keys(schema.attributeIndexes).forEach(function(att) {
             if (!schema.iKeyMap[att] && !secondaryKeySet[att]) {
                 secondaryKeySet[att] = true;
-                newerProj.push(att);
             }
         });
     });
     var secondaryKeys = Object.keys(secondaryKeySet);
 
-    if (!secondaryKeySet[tidKey]) {
-        newerProj.push(tidKey);
-    }
 
     // XXX: handle the case where reqTid is not defined!
     var reqTid = query.attributes[schema.tid];
@@ -566,7 +554,6 @@ DB.prototype._backgroundUpdates = function(req, limit, indexes) {
     newerDataQuery.order = {};
     newerDataQuery.order[schema.tid] = 'asc'; // select sibling entries
     newerDataQuery.limit = 2; // data entry + newer entry
-    newerDataQuery.proj = newerProj;
     var newerRebuildRequest = req.extend({
         query: newerDataQuery
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "^2.2.2",


### PR DESCRIPTION
There's a whole bunch of bugs being fixed here:
- The TTL policy didn't work on cassandra, but that was unnoticed because of a bug in the test. The problem is that TTL is column-based in cassandra, so to actually set a TTL when writing a row, we need to have at least one non-null non-primary-key value in the row. But in revPolicy update code, we were fetching only key columns and those needed for secondary indexes, so for tables with no sec indexes TTL was not set up. Easy to fix by dropping the custom proj and fetching everything. We don't loose to much on the speed here, because it affects only a single row.
- After that being fixed, I've run into a bug in cassandra, that affects our tests. The bug is present in 2.1.* but fixed in 2.2.*. The problem was, that when you add a static column to an existing table, and try to fetch values of this column using `order by` query, the requests timeout. This is a problem for us when the table has a revPolicy and we add a static column there. Workaround for this bug is too complicated, so I've left everything as is, just modified the tests to not run into this problem.

The corresponding changes of the spec module are here: https://github.com/wikimedia/restbase-mod-table-spec/pull/29
The tests would fail until the spec changes are published.