### PR TITLE
Don't require early returns

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -20,6 +20,7 @@
   "requireTrailingComma": null,
   "disallowTrailingComma": null,
   "requireSpacesInsideObjectBrackets": "all",
+  "requireEarlyReturn": false,
 
   "excludeFiles": [
     "node_modules/**",


### PR DESCRIPTION
Latest jscs seems to have started to disallow constructs of this form by
default:

if (something) {
    return a;
} else {
    return b;
}

I personally think this form is fine, especially if the branches are short.
The existing code also uses this quite often.