### PR TITLE
Update parameters for DTCS tables & improve backend migration

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -638,25 +638,6 @@ DB.prototype._delete = function(req) {
     return this._put(req);
 };
 
-/**
- * Evaluate, and if neccessary, perform a migration from one back-end version
- * to another.
- *
- * @param  {object} req;  the current request object
- * @param  {object} from; schema info object representing current state
- * @param  {object} to;   schema info object representing proposed state
- * @return {boolean} a promise that resolves to true if a back-end migration
- *         occurred.
- */
-DB.prototype._migrateBackend = function(req, from, to) {
-    // Perform a backend migration, as-needed.
-    switch (from._backend_version) {
-    case 0:
-        return this._dropDomainIndex(req);
-    default:
-        return P.resolve();
-    }
-};
 
 /**
  * Conditionally performs a table schema and/or back-end migration.

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -944,7 +944,7 @@ var updateOptionMap = {
         // http://thread.gmane.org/gmane.comp.db.cassandra.devel/9753 and
         // http://mail-archives.apache.org/mod_mbox/cassandra-commits/201405.mbox/%3C8eaf7fbf908a4e40a77bc26b69ac7867@git.apache.org%3E
         + "'tombstone_threshold': '0.1', 'unchecked_tombstone_compaction': 'true', "
-        // Set the max window size (sstables to compact together) to three months.
+        // Set the max window size (sstables to compact together) to two months.
         + "'max_window_size_seconds': '5184000'}"
         // TODO: Calculate this based on the retention policy?
         + " and gc_grace_seconds = 86400",

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -200,7 +200,7 @@ dbu.eachRow = function eachRow(client, query, params, options, handler) {
  */
 
 dbu.DEFAULT_BACKEND_VERSION = 0;
-dbu.CURRENT_BACKEND_VERSION = 1;
+dbu.CURRENT_BACKEND_VERSION = 2;
 
 dbu.DEFAULT_CONFIG_VERSION = 0;    // Implicit module config version.
 
@@ -937,18 +937,15 @@ var updateOptionMap = {
         + "'tombstone_threshold': '0.02' }",
     'random-update': "{ 'class' : 'LeveledCompactionStrategy' }",
     timeseries: "{ 'class': 'DateTieredCompactionStrategy', "
-        // Change base_time_seconds from 60s default to 45, for better
-        // alignment with two-day expiry (24 hour TTL + 24 hour
-        // gc_grace_seconds). See also:
-        // https://issues.apache.org/jira/browse/CASSANDRA-8417
-        + "'base_time_seconds': '45',"
         // More aggressive tombstone collection. Changes from defaults:
-        // - Lowered tombstone_threshold from 0.2 to 0.02
+        // - Lowered tombstone_threshold from 0.2 to 0.1
         // - Enabled unchecked_tombstone_compaction, which allows tombstone
         // collection even if key ranges overlap with other sstables. See
         // http://thread.gmane.org/gmane.comp.db.cassandra.devel/9753 and
         // http://mail-archives.apache.org/mod_mbox/cassandra-commits/201405.mbox/%3C8eaf7fbf908a4e40a77bc26b69ac7867@git.apache.org%3E
-        + "'tombstone_threshold': '0.02', 'unchecked_tombstone_compaction': 'true' }"
+        + "'tombstone_threshold': '0.1', 'unchecked_tombstone_compaction': 'true', "
+        // Set the max window size (sstables to compact together) to three months.
+        + "'max_window_size_seconds': '5184000'}"
         // TODO: Calculate this based on the retention policy?
         + " and gc_grace_seconds = 86400",
 };

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -341,7 +341,22 @@ BackendMigrator.prototype.validate = function(req, current, proposed) {
 };
 
 BackendMigrator.prototype.migrate = function(req, current, proposed) {
-    return this.options.db.migrateBackend(req, current, proposed);
+    var self = this;
+    var migration = P.resolve();
+    // Perform a backend migration, as-needed.
+    if (current._backend_version <= 0) {
+        migration = migration.then(function() {
+            return self.options.db._dropDomainIndex(req);
+        });
+    }
+    if (current._backend_version <= 1) {
+        migration = migration.then(function() {
+            var optMigrator = new Options(self.options);
+            optMigrator.validate(req, current, proposed);
+            return optMigrator.migrate(req, current, proposed);
+        });
+    }
+    return migration;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.13",
+  "version": "0.9.0",
   "dependencies": {
     "bluebird": "~2.8.2",
     "cassandra-driver": "^2.2.2",


### PR DESCRIPTION
This patch updates DTCS parameters for current stable Cassandra (2.2.4 and
2.1.12) by setting max_window_size_seconds explicitly, and dropping some less
important parameters. The exact settings aren't completely final yet, so we
might want to wait with applying this for a week or two until we have gotten a
bit more data on good defaults. These settings in particular are somewhat
questionable:
- unchecked_tombstone_compaction is disabled on some high-traffic prod tables,
  but we might want to revisit this in light of 2.1.12.
- tombstone_threshold: Set to 0.15 on high-traffic prod tables, but might also
  want to lower this in light of the increased compaction headroom in
  2.1.12. The current patch specified 0.1, which might be a good balance.
- max_window_size_seconds is set to 60 days in large production tables & this
  patch. We might want to increase this.

This patch also provides a backend migration pass to apply these parameter
changes. To make it easy to call other schema migrators, the main
BackendMigrator code now has all the logic needed.
