### PR TITLE
Don't mess with write timestamps and allow overwriting rows

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -415,8 +415,6 @@ DB.prototype._put = function(req) {
         query.attributes[schema.tid] = TimeUuid.fromString(query.attributes[schema.tid]);
     }
 
-    query.timestamp = dbu.tidNanoTime(query.attributes[schema.tid]);
-
     // insert into secondary Indexes first
     var batch = [];
     if (schema.secondaryIndexes) {

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -19,7 +19,7 @@ function RevisionPolicyManager(db, request, schema) {
     this.count = 0;
     if (this.policy.type === 'interval') {
         var interval = this.policy.interval * 1000;
-        var tidTime = this.request.query.timestamp;
+        var tidTime = this.request.query.attributes[this.request.schema.tid].getDate();
         this.intervalLimitTime = tidTime - tidTime % interval;
     } else {
         this.intervalLimitTime = null;
@@ -29,7 +29,6 @@ function RevisionPolicyManager(db, request, schema) {
 RevisionPolicyManager.prototype._setTtl = function(item) {
     var self = this;
     self.request.query.attributes = item;
-    self.request.query.timestamp = null;
 
     var query = dbu.buildPutQuery(self.request, true);
     var queryOptions = { consistency: self.request.consistency, prepare: true };

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -9,8 +9,9 @@ var P = require('bluebird');
  * @param {object} db; instance of DB
  * @param {object} request; request to use as baseline
  * @param {object} schema; the table schema
+ * @param {Date} reqTime; the request time derived from request tid
  */
-function RevisionPolicyManager(db, request, schema) {
+function RevisionPolicyManager(db, request, schema, reqTime) {
     this.db = db;
     this.schema = schema;
     this.policy = schema.revisionRetentionPolicy;
@@ -19,8 +20,7 @@ function RevisionPolicyManager(db, request, schema) {
     this.count = 0;
     if (this.policy.type === 'interval') {
         var interval = this.policy.interval * 1000;
-        var tidTime = this.request.query.attributes[this.request.schema.tid].getDate();
-        this.intervalLimitTime = tidTime - tidTime % interval;
+        this.intervalLimitTime = reqTime - reqTime % interval;
     } else {
         this.intervalLimitTime = null;
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "dependencies": {
     "bluebird": "^3.1.1",
     "cassandra-driver": "^2.2.2",


### PR DESCRIPTION
In our system every db entry has a tid, which for us works as internal cassandra timestamp. We've used to assign the write timestamp the same as tid, so when we wanted to overwrite the value, there was a conflict and a new value was chosen by cassandra in unpredictable manner. 

Also, some miner improvements to revision policies are made: as we don't mess with timestamps any more, we rely on tid in the retention policy, which is actually way more correct.

Test here: https://github.com/wikimedia/restbase-mod-table-spec/pull/35

cc @wikimedia/services 