### PR TITLE
Performance: Switch to our own fork of cassandra-driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "dependencies": {
     "bluebird": "^3.1.1",
-    "cassandra-driver": "^2.2.2",
+    "cassandra-driver": "git+https://github.com/wikimedia/nodejs-driver#optimizations",
     "core-js": "^2.0.3",
     "extend": "^3.0.0",
     "js-yaml": "^3.5.2",


### PR DESCRIPTION
We have a custom fork of the cassandra driver with several performance
improvements:

- Using `neo-async` instead of `async` reduces memory consumption
  significantly, which might eliminate worker restarts.
- Elimination of a couple of known-expensive operations
  (Object.defineProperty, bind) in a few strategic places lets V8 optimize the
  code better.

Overall, these changes yield about a 10% throughput improvement when tested
with
`ab -c20 -n 100000 http://localhost:7231/en.wikipedia.org/v1/page/html/FOO`.
The bigger impact is on memory however, with resident memory per worker
dropping from around 200m (and growing) to a stable ~118m.