### PR TITLE
Set maxVersion 3 for the duration of the Cassandra upgrade

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -72,7 +72,7 @@ function makeClient(options) {
     // Increase the schema agreement wait period from the default of 10s
     clientOpts.protocolOptions = {
         maxSchemaAgreementWaitSeconds: 30,
-        maxProtocolVersion: 3
+        maxVersion: 3
     };
 
     if (conf.username && conf.password) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.1.1",


### PR DESCRIPTION
Fixes the last commit that typo'd maxVersion as maxProtocolVersion

Bug: https://phabricator.wikimedia.org/T126629