### PR TITLE
key_rev_value-based revision culling

### DIFF
--- a/maintenance/lib/index.js
+++ b/maintenance/lib/index.js
@@ -29,6 +29,15 @@ ARP.onReadTimeout = function(requestInfo) {
     return { decision: 1 };
 };
 
+function makeClient(options) {
+    var creds = options.credentials;
+    return new cassandra.Client({
+        contactPoints: [options.host],
+        authProvider: new cassandra.auth.PlainTextAuthProvider(creds.username, creds.password),
+        socketOptions: { connectTimeout: 10000 },
+    });
+}
+
 function getQuery(tableName, offsets) {
     var cql = 'SELECT "_domain", key, rev, tid, token("_domain",key) AS "_token" FROM ' + tableName;
     var params = [];
@@ -110,4 +119,7 @@ function processRows(client, tableName, offsets, func) {
     });
 }
 
-module.exports = processRows;
+module.exports = {
+    iterateTable: processRows,
+    makeClient: makeClient,
+};

--- a/maintenance/lib/iterateTable.js
+++ b/maintenance/lib/iterateTable.js
@@ -1,0 +1,112 @@
+"use strict";
+
+
+var P = require('bluebird');
+var cassandra = P.promisifyAll(require('cassandra-driver'));
+var consistencies = cassandra.types.consistencies;
+var util = require('util');
+
+
+// A custom retry policy
+function AlwaysRetry () {}
+util.inherits(AlwaysRetry, cassandra.policies.retry.RetryPolicy);
+var ARP = AlwaysRetry.prototype;
+// Always retry.
+ARP.onUnavailable = function(requestInfo) {
+    // Reset the connection
+    requestInfo.handler.connection.close(function() {
+        requestInfo.handler.connection.open(function(){});
+    });
+    return { decision: 1 };
+};
+ARP.onWriteTimeout = function() { return { decision: 2 }; };
+ARP.onReadTimeout = function(requestInfo) {
+    // Reset the connection
+    requestInfo.handler.connection.close(function() {
+        requestInfo.handler.connection.open(function(){});
+    });
+    console.log('read retry');
+    return { decision: 1 };
+};
+
+function getQuery(offsets) {
+    var cql = 'SELECT "_domain", key, rev, tid, token("_domain",key) AS "_token" FROM data';
+    var params = [];
+    if (offsets.token) {
+        cql += ' WHERE token("_domain",key) >= ?';
+        params.push(offsets.token);
+    } else if (offsets.domain) {
+        cql += ' WHERE token("_domain",key) >= token(?, ?)';
+        params.push(offsets.domain);
+        params.push(offsets.key);
+    }
+    return {
+        cql: cql,
+        params: params,
+    };
+}
+
+function nextPage(client, offsets, retryDelay) {
+    //console.log(offsets);
+    var query = getQuery(offsets);
+    return client.executeAsync(query.cql, query.params, {
+        prepare: true,
+        fetchSize: retryDelay ? 1 : 50,
+        pageState: offsets.pageState,
+        consistency: retryDelay ? consistencies.one : consistencies.quorum,
+    })
+    .catch(function(err) {
+        retryDelay = retryDelay || 1; // ms
+        if (retryDelay < 20 * 1000) {
+            retryDelay *= 2 + Math.random();
+        } else if (offsets.token) {
+            // page over the problematic spot
+            console.log('Skipping over problematic token:',
+                offsets.token.toString());
+            offsets.token = offsets.token.add(500000000);
+            console.log('Retrying with new token:',
+                offsets.token.toString());
+            return nextPage(client, offsets, retryDelay);
+        }
+
+        console.log('Error:', err);
+        console.log('PageState:', offsets.pageState);
+        console.log('Last token:', offsets.token.toString());
+        console.log('Retrying in', Math.round(retryDelay) / 1000, 'seconds...');
+        return new P(function(resolve, reject) {
+            setTimeout(function() {
+                nextPage(client, offsets, retryDelay)
+                    .then(resolve)
+                    .catch(reject);
+            }, retryDelay);
+        });
+    });
+}
+
+/**
+ * Iterate rows in a key-rev-value table.
+ *
+ * @param {cassandra#Client} client - Cassandra client instance.
+ * @param {Object}   offsets - Offset information (token, domain, key, and pageState).
+ * @param {Function} func - Function called with result rows.
+ */
+function processRows(client, offsets, func) {
+    return nextPage(client, offsets)
+    .then(function(res) {
+        return P.resolve(res.rows)
+        .each(func)
+        .then(function() {
+            process.nextTick(function() {
+                offsets.pageState = res.pageState;
+                processRows(client, offsets, func);
+            });
+        })
+        .catch(function(e) {
+            console.log(res.pageState);
+            console.log(e);
+            throw e;
+        });
+    });
+}
+
+module.exports = processRows;

--- a/maintenance/thin_out_parsoid.js
+++ b/maintenance/thin_out_parsoid.js
@@ -12,7 +12,8 @@ var P = require('bluebird');
 var cassandra = P.promisifyAll(require('cassandra-driver'));
 var consistencies = cassandra.types.consistencies;
 var ctypes = cassandra.types;
-var iterateTable = require('./lib/iterateTable');
+var iterateTable = require('./lib/index').iterateTable;
+var makeClient = require('./lib/index').makeClient;
 var DB = require('../lib/db');
 var dbutil = require('../lib/dbutils');
 var yaml = require('js-yaml');
@@ -67,15 +68,12 @@ if ((argv.token && (argv.title || argv.pageState))
     process.exit(1);
 }
 
-function makeClient() {
-    return new cassandra.Client({
-        contactPoints: [argv.host],
-        authProvider: new cassandra.auth.PlainTextAuthProvider('cassandra', 'cassandra'),
-        socketOptions: { connectTimeout: 10000 },
-    });
-}
-
-var client = makeClient();
+var client = makeClient({
+    host: argv.host,
+    credentials: {
+        username: 'cassandra', password: 'cassandra'
+    }
+});
 var config = process.env.CONFIG || '/etc/restbase/config.yaml';
 var confObj = yaml.safeLoad(fs.readFileSync(config));
 confObj = confObj.default_project['x-modules'][0].options.table;

--- a/maintenance/thin_out_parsoid.js
+++ b/maintenance/thin_out_parsoid.js
@@ -1,0 +1,176 @@
+"use strict";
+
+/*
+ * Known Issues:
+ *   - The token must be supplied in the form --token=, to prevent yargs from
+ *     parsing negative values as a flag.
+ *
+ */
+
+
+var P = require('bluebird');
+var cassandra = P.promisifyAll(require('cassandra-driver'));
+var consistencies = cassandra.types.consistencies;
+var ctypes = cassandra.types;
+var iterateTable = require('./lib/iterateTable');
+var DB = require('../lib/db');
+var dbutil = require('../lib/dbutils');
+var yaml = require('js-yaml');
+var fs = require('fs');
+
+
+var yargs = require('yargs')
+    .usage('Usage: $0 -H HOST -g GROUP [--token TOKEN]\n' +
+           'Usage: $0 -H HOST -g GROUP [--title TITLE]\n' +
+           'Usage: $0 -H HOST -g GROUP [--pageState STATE]\n\n' +
+           'Prune RESTBase Parsoid storage revisions')
+    .demand(['host', 'domain'])
+    .options('h', {alias: 'help'})
+    .options('H', {
+        alias: 'host',
+        describe: 'Cassandra hostname (contact node)',
+        type: 'string'
+    })
+    .options('d', {
+        alias: 'domain',
+        describe: 'Domain that will match to storage group',
+        type: 'string',
+    })
+    .options('t', {
+        alias: 'token',
+        describe: 'Cassandra token ID to start from',
+        type: 'string',
+    })
+    .options('T', {
+        alias: 'title',
+        describe: 'Page title to start from',
+        type: 'string',
+    })
+    .options('s', {
+        alias: 'pageState',
+        describe: 'Driver page state to start from',
+        type: 'string',
+    });
+
+var argv = yargs.argv;
+
+if (argv.h) {
+    yargs.showHelp();
+    process.exit(0);
+}
+
+if ((argv.token && (argv.title || argv.pageState))
+    || (argv.title && (argv.token || argv.pageState))
+    || (argv.pageState && (argv.token || argv.title))) {
+    yargs.showHelp();
+    console.error('Error: You can only set one of --token, --title, or --pageState');
+    process.exit(1);
+}
+
+function makeClient() {
+    return new cassandra.Client({
+        contactPoints: [argv.host],
+        authProvider: new cassandra.auth.PlainTextAuthProvider('cassandra', 'cassandra'),
+        socketOptions: { connectTimeout: 10000 },
+    });
+}
+
+var client = makeClient();
+var config = process.env.CONFIG || '/etc/restbase/config.yaml';
+var confObj = yaml.safeLoad(fs.readFileSync(config));
+confObj = confObj.default_project['x-modules'][0].options.table;
+var db = new DB(client, {conf: confObj, log: console.log});
+var htmlTable = dbutil.cassID(db._keyspaceName(argv.domain, 'parsoid.html')) + '.data';
+var dataTable = dbutil.cassID(db._keyspaceName(argv.domain, 'parsoid.data-parsoid')) + '.data';
+console.log('html:', htmlTable);
+console.log('data:', dataTable);
+
+// Row state, used to make row handling decisions in processRow
+var counts = {
+    title: 0,
+    rev: 0,
+    render: 0,
+};
+
+var keys = {
+    title: null,
+    rev: null,
+};
+
+var total = 0;
+
+// Parse optional start offsets
+var startOffset = {
+    token: null,
+    key: null,
+    pageState: null,
+};
+
+if (argv.token) {
+    if (!(/^-?[0-9]{1,30}$/.test(argv.token) && parseInt(argv.token))) {
+        yargs.showHelp();
+        console.error("Invalid token:", argv.token);
+        process.exit(1);
+    }
+    startOffset.token = ctypes.Long.fromString(argv.token);
+} else if (argv.title) {
+    startOffset.key = argv.title;
+} else if (argv.pageState) {
+    startOffset.pageState = argv.pageState;
+}
+
+function processRow (row) {
+    // Create a new set of keys
+    var newKeys = {
+        title: JSON.stringify([row._domain, row.key]),
+        rev: JSON.stringify([row._domain, row.key, row.rev])
+    };
+
+    // Keep track of our latest token
+    startOffset.token = row._token;
+
+    // Diff the keys and update counters
+    if (newKeys.title !== keys.title) {
+        counts.title = 0;
+        counts.rev = 0;
+        counts.render = 0;
+    } else if (newKeys.rev !==  keys.rev) {
+        counts.rev++;
+        counts.render = 0;
+    } else {
+        counts.render++;
+    }
+    keys = newKeys;
+
+    total++;
+    if ((total % 500000) === 0) {
+        console.log(new Date() + ': processed ' + total + ' total entries');
+    }
+
+    // Thin-out
+    if ((counts.rev > 0 && counts.render > 0)
+        || (counts.rev === 0 && counts.render > 0
+            // Enforce a grace_ttl of 86400
+            && (Date.now() - row.tid.getDate()) > 86400000)
+        || (counts.rev > 0 && row.tid.getDate() <  Date.parse('2015-12-31T23:59-0000'))) {
+        console.log('-- Deleting:', row._token.toString(), row.tid.getDate().toISOString(), keys.rev);
+
+        var delQuery1 = 'DELETE FROM ' + htmlTable + ' WHERE "_domain" = ? AND key = ? AND rev = ? AND tid = ?';
+        var delQuery2 = 'DELETE FROM ' + dataTable + ' WHERE "_domain" = ? AND key = ? AND rev = ? AND tid = ?';
+        var params = [row._domain, row.key, row.rev, row.tid];
+        var delQueries = [
+            { query: delQuery1, params: params },
+            { query: delQuery2, params: params }
+        ];
+
+        return client.batchAsync(delQueries, {
+            prepare: true,
+            consistency: cassandra.types.consistencies.localQuorum
+        });
+    }
+
+    // Else: nothing to do
+    return P.resolve();
+}
+
+return iterateTable(client, htmlTable, startOffset, processRow);


### PR DESCRIPTION
Moves title iteration out to its own module, and re-uses it to create a Parsoid-specific thinning script.  This new script performs corresponding deletes to data-parsoid as part of a batch operation.  Since both entries share the same partition key, this is atomic, isolated, and performant.

This is still quite rough, but I wanted to get it put up, and more eyes on it, before taking it much further.

Comments appreciated.