### PR TITLE
Update driver to v3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.1.1",
-    "cassandra-driver": "git+https://github.com/wikimedia/nodejs-driver#neo-async",
+    "cassandra-driver": "^3.1.1",
     "core-js": "^2.0.3",
     "extend": "^3.0.0",
     "js-yaml": "^3.5.2",


### PR DESCRIPTION
Some time ago we've switched to driver to our own fork that replaced `async` lib with `neo-async` to get some boots in performance and memory consumption. However, during that time a lot of work has been done on the upstream driver. For instance, `async` dependency was removed completely.

Current `neo-async` branch is equal to driver's `3.0.1` version.

I've done some basic testing of the new driver and it seems to work correctly. Performance is ~15% better then with our current version and memory consumption decreases from 220 Mb to 160 Mb per worker under load.

Testing in staging is required for this change, so bumping the version to `0.10`.

cc @wikimedia/services 