### PR TITLE
Do not include the full request body in errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,11 @@ RBCassandra.prototype.get = function(rb, req) {
                 title: 'Error in Cassandra table storage backend',
                 stack: e.stack,
                 err: e,
-                req: req
+                req: {
+                    uri: req.uri,
+                    headers: req.headers,
+                    body: req.body && JSON.stringify(req.body).slice(0,200)
+                }
             }
         };
     });
@@ -114,7 +118,11 @@ RBCassandra.prototype.put = function(rb, req) {
                 title: 'Internal error in Cassandra table storage backend',
                 stack: e.stack,
                 err: e,
-                req: req
+                req: {
+                    uri: req.uri,
+                    headers: req.headers,
+                    body: req.body && JSON.stringify(req.body).slice(0,200)
+                }
             }
         };
     });
@@ -136,7 +144,11 @@ RBCassandra.prototype.dropTable = function(rb, req) {
                 title: 'Internal error in Cassandra table storage backend',
                 stack: e.stack,
                 err: e,
-                req: req
+                req: {
+                    uri: req.uri,
+                    headers: req.headers,
+                    body: req.body && JSON.stringify(req.body).slice(0,200)
+                }
             }
         };
     });
@@ -160,7 +172,11 @@ RBCassandra.prototype.getTableSchema = function(rb, req) {
                 title: 'Internal error querying table schema in Cassandra storage backend',
                 stack: e.stack,
                 err: e,
-                req: req
+                req: {
+                    uri: req.uri,
+                    headers: req.headers,
+                    body: req.body && JSON.stringify(req.body).slice(0,200)
+                }
             }
         };
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.1.1",


### PR DESCRIPTION
Reduce the verbosity of storage backend errors by not including full request
bodies in the error object. Instead, the body is serialized to a JSON string,
and only the first 200 bytes of this string are returned.

Task: https://phabricator.wikimedia.org/T141384