### PR TITLE
Optimise the TTL revision retention policy

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -375,6 +375,12 @@ class DB {
             });
         }
 
+        if (schema.revisionRetentionPolicy
+                && schema.revisionRetentionPolicy.type === 'latest'
+                && schema.revisionRetentionPolicy.count === 0) {
+            req.ttl = schema.revisionRetentionPolicy.grace_ttl;
+        }
+
         batch.push(dbu.buildPutQuery(req));
 
         const queryOptions = { consistency: req.consistency, prepare: true };
@@ -1024,7 +1030,10 @@ DB.prototype._shouldRunBackgroundUpdates = (schema, indexes) => {
     // there are no revisions to cull), then there is no need to run
     // background updates.
     return indexes.length
-        || schema.revisionRetentionPolicy && schema.revisionRetentionPolicy.type !== 'all';
+        || schema.revisionRetentionPolicy
+            && schema.revisionRetentionPolicy.type !== 'all'
+            && !(schema.revisionRetentionPolicy.type === 'latest'
+                && schema.revisionRetentionPolicy.count === 0);
 };
 
 module.exports = DB;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -77,7 +77,7 @@ dbu.hashKey = function hashKey(key) {
         .digest()
         .toString('base64')
         // Replace [+/] from base64 with _ (illegal in Cassandra)
-        .replace(/[+\/]/g, '_')
+        .replace(/[+/]/g, '_')
         // Remove base64 padding, has no entropy
         .replace(/=+$/, '');
 };

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -17,7 +17,8 @@ class RevisionPolicyManager {
         this.schema = schema;
         this.policy = schema.revisionRetentionPolicy;
         this.request = dbu.makeRawRequest(request, { ttl: this.policy.grace_ttl });
-        this.noop = this.policy.type === 'all';
+        this.noop = this.policy.type === 'all' ||
+            (this.policy.type === 'latest' && this.policy.count === 0);
         this.count = 0;
         if (this.policy.type === 'interval') {
             const interval = this.policy.interval * 1000;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.6",


### PR DESCRIPTION
For the TTL policy we can avoid doing 'write -> read -> update' pattern because we always know that the TTL will be set, so we can skip the normal revision policy update and write with TTL right away.

Bug: https://phabricator.wikimedia.org/T150703