### PR TITLE
Update to a newer cassandra driver and use built-in promise support

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -173,7 +173,7 @@ class DB {
                 return req;
             } else {
                 // Check if the meta column family exists
-                return this.client.execute_p('SELECT columnfamily_name FROM '
+                return this.client.execute('SELECT columnfamily_name FROM '
                     + 'system.schema_columnfamilies WHERE keyspace_name=? '
                     + 'and columnfamily_name=?', [req.keyspace, 'meta'])
                 .then((res) => {
@@ -299,7 +299,7 @@ class DB {
         }
 
         const buildResult = dbu.buildGetQuery(req, options);
-        return this.client.execute_p(buildResult.cql, buildResult.params, cassOpts)
+        return this.client.execute(buildResult.cql, buildResult.params, cassOpts)
         .then((result) => {
             const rows = result.rows;
             // Decorate the row result with the _ttl attribute.
@@ -388,13 +388,13 @@ class DB {
         if (batch.length === 1) {
             // Single query only (no secondary indexes): no need for a batch.
             const queryInfo = batch[0];
-            update = this.client.execute_p(queryInfo.cql, queryInfo.params, queryOptions);
+            update = this.client.execute(queryInfo.cql, queryInfo.params, queryOptions);
         } else {
             const driverBatch = batch.map((queryInfo) => ({
                 query: queryInfo.cql,
                 params: queryInfo.params
             }));
-            update = this.client.batch_p(driverBatch, queryOptions);
+            update = this.client.batch(driverBatch, queryOptions);
         }
 
         if (schema.revisionRetentionPolicy
@@ -420,7 +420,7 @@ class DB {
                 predicates[att] = row[att];
             });
             const condition = dbu.buildCondition(predicates, req.schema, true);
-            return this.client.execute_p(cql + condition.cql, condition.params, { prepare: true })
+            return this.client.execute(cql + condition.cql, condition.params, { prepare: true })
             .catch((e) => {
                 this.log('error/table/cassandra/revisionRetentionPolicyUpdate', e);
             });
@@ -836,18 +836,18 @@ class DB {
         });
 
         // Execute the table creation query
-        return tasks.then(() => this.client.execute_p(cql, [], { consistency: req.consistency }));
+        return tasks.then(() => this.client.execute(cql, [], { consistency: req.consistency }));
     }
 
     // Drop the native secondary indexes we used to create on the "_domain" column.
     _dropDomainIndex(req) {
         const cql = "select index_name from system.schema_columns where keyspace_name = ? "
             + " and columnfamily_name = ? and column_name = '_domain';";
-        return this.client.execute_p(cql, [req.keyspace, req.columnfamily], { prepare: true })
+        return this.client.execute(cql, [req.keyspace, req.columnfamily], { prepare: true })
         .then((res) => {
             if (res.rows.length && res.rows[0].index_name) {
                 // drop the index
-                return this.client.execute_p(`drop index if exists `
+                return this.client.execute(`drop index if exists `
                     + `${cassID(req.keyspace)}.${cassID(res.rows[0].index_name)}`);
             }
         });
@@ -856,7 +856,7 @@ class DB {
     _createKeyspace(req) {
         const cql = `create keyspace if not exists ${cassID(req.keyspace)} `
             + `WITH REPLICATION = ${this._createReplicationOptionsCQL(req.query.options)}`;
-        return this.client.execute_p(cql, [],
+        return this.client.execute(cql, [],
                 { consistency: req.consistency || this.defaultConsistency });
     }
 
@@ -884,7 +884,7 @@ class DB {
     dropTable(domain, table) {
         const keyspace = this.keyspaceName(domain, table);
         this.schemaCache[keyspace] = null;
-        return this.client.execute_p(`drop keyspace ${cassID(keyspace)}`, [],
+        return this.client.execute(`drop keyspace ${cassID(keyspace)}`, [],
                 { consistency: this.defaultConsistency });
     }
 
@@ -953,7 +953,7 @@ class DB {
             replicas: this._replicationPolicy(options),
             durability: options && options.durability || null
         });
-        return this.client.execute_p(cql, [], { consistency: this.defaultConsistency });
+        return this.client.execute(cql, [], { consistency: this.defaultConsistency });
     }
 
     /**

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -128,7 +128,7 @@ dbu.assignMaxTTL = function assignMaxTTL(row) {
 };
 
 function _nextPage(client, query, params, pageState, options) {
-    return P.try(() => client.execute_p(query, params, {
+    return P.try(() => client.execute(query, params, {
         prepare: true,
         fetchSize: options.fetchSize || 5,
         pageState,

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,6 @@ const loadBalancing = cass.policies.loadBalancing;
 const reconnection = cass.policies.reconnection;
 const DB = require('./db');
 
-P.promisifyAll(cass, { suffix: '_p' });
-
 function validateAndNormalizeDcConf(conf) {
     // Default to 'datacenter1'
     if (!conf.localDc) { conf.localDc = 'datacenter1'; }
@@ -82,6 +80,7 @@ function makeClient(options) {
 
     // Up the maximum number of prepared statements. Driver default is 500.
     clientOpts.maxPrepared = conf.maxPrepared || 50000;
+    clientOpts.promiseFactory = P.fromCallback;
 
     const client = new cass.Client(clientOpts);
 
@@ -107,7 +106,7 @@ function makeClient(options) {
         });
     });
 
-    return client.connect_p()
+    return client.connect()
     .then(() => new DB(client, options));
 }
 

--- a/lib/revisionPolicy.js
+++ b/lib/revisionPolicy.js
@@ -34,7 +34,7 @@ class RevisionPolicyManager {
         const query = dbu.buildPutQuery(this.request, true);
         const queryOptions = { consistency: this.request.consistency, prepare: true };
 
-        return this.db.client.execute_p(query.cql, query.params, queryOptions)
+        return this.db.client.execute(query.cql, query.params, queryOptions)
         .catch((e) => {
             this.db.log('error/table/cassandra/revisionRetentionPolicyUpdate', e);
         });

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -77,7 +77,7 @@ class Options {
         const table = `${dbu.cassID(req.keyspace)}.${dbu.cassID(req.columnfamily)}`;
         const cql = `ALTER TABLE ${table} WITH ${dbu.getOptionCQL(proposed.options,
         this.options.db)}`;
-        return this.options.client.execute_p(cql, [], { consistency: req.consistency });
+        return this.options.client.execute(cql, [], { consistency: req.consistency });
     }
 }
 
@@ -101,7 +101,7 @@ class Attributes {
                 column: col
             });
             const cql = this._alterTableAdd(proposed, table, col);
-            return this.options.client.execute_p(cql, [], { consistency: req.consistency })
+            return this.options.client.execute(cql, [], { consistency: req.consistency })
             .catch((e) => {
                 if (!new RegExp(`Invalid column name ${col} because it `
                         + `conflicts with an existing column`).test(e.message)) {
@@ -117,7 +117,7 @@ class Attributes {
                 column: col
             });
             const cql = `ALTER TABLE ${table} DROP ${dbu.cassID(col)}`;
-            return this.options.client.execute_p(cql, [], { consistency: req.consistency })
+            return this.options.client.execute(cql, [], { consistency: req.consistency })
             .catch({ message: `Column ${col} was not found in table data` }, () => {
                 // Ignore the error if the column was already removed.
             });

--- a/lib/secondaryIndexes.js
+++ b/lib/secondaryIndexes.js
@@ -111,7 +111,7 @@ class IndexRebuilder {
             });
             const queryObj = dbu.buildPutQuery(idxReq, true);
             queries.push(
-                this.db.client.execute_p(queryObj.cql, queryObj.params,
+                this.db.client.execute(queryObj.cql, queryObj.params,
                     { consistency: cass.types.consistencies.localOne, prepare: true })
                 .catch((e) => {
                     this.db.log('error/table/cassandra/secondaryIndexUpdate', e);
@@ -133,7 +133,7 @@ class IndexRebuilder {
                 });
                 const delQueryObj = dbu.buildPutQuery(delReq, true);
                 queries.push(
-                    this.db.client.execute_p(delQueryObj.cql, delQueryObj.params,
+                    this.db.client.execute(delQueryObj.cql, delQueryObj.params,
                         { consistency: cass.types.consistencies.localOne, prepare: true })
                     .catch((e) => {
                         this.db.log('error/table/cassandra/secondaryIndexUpdate', e);

--- a/maintenance/lib/index.js
+++ b/maintenance/lib/index.js
@@ -2,7 +2,7 @@
 
 
 var P   = require('bluebird');
-var cassandra     = P.promisifyAll(require('cassandra-driver'));
+var cassandra     = require('cassandra-driver');
 var consistencies = cassandra.types.consistencies;
 var fs   = require('fs');
 var util = require('util');
@@ -37,6 +37,7 @@ function makeClient(options) {
         contactPoints: [options.host],
         authProvider: new cassandra.auth.PlainTextAuthProvider(creds.username, creds.password),
         socketOptions: { connectTimeout: 10000 },
+        promiseFactory: P.fromCallback
     });
 }
 
@@ -60,7 +61,7 @@ function getQuery(tableName, offsets) {
 function nextPage(client, tableName, offsets, retryDelay) {
     //console.log(offsets);
     var query = getQuery(tableName, offsets);
-    return client.executeAsync(query.cql, query.params, {
+    return client.execute(query.cql, query.params, {
         prepare: true,
         fetchSize: retryDelay ? 1 : 50,
         pageState: offsets.pageState,

--- a/maintenance/thin_out_key_rev_value_data.js
+++ b/maintenance/thin_out_key_rev_value_data.js
@@ -136,7 +136,7 @@ function processRow (row) {
         console.log('-- Deleting:', row._token.toString(), row.tid.getDate().toISOString(), keys.rev);
         var delQuery = 'delete from ' + table + 'where "_domain" = :domain and key = :key and rev = :rev and tid = :tid';
         row.domain = row._domain;
-        return client.executeAsync(delQuery, row, {
+        return client.execute(delQuery, row, {
             prepare: true,
             consistency: cassandra.types.consistencies.quorum
         });

--- a/maintenance/thin_out_parsoid.js
+++ b/maintenance/thin_out_parsoid.js
@@ -191,7 +191,7 @@ function processRow (row) {
             { query: delOffsets, params: params },
         ];
 
-        return client.batchAsync(delQueries, {
+        return client.batch(delQueries, {
             prepare: true,
             consistency: cassandra.types.consistencies.localQuorum
         });

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.6",
-    "cassandra-driver": "^3.1.4",
+    "cassandra-driver": "^3.2.0",
     "core-js": "^2.4.1",
     "extend": "^3.0.0",
     "js-yaml": "^3.6.1",


### PR DESCRIPTION
The new driver version is released and it has built-in promise support - let's use it!

I've measured the performance locally a bit, but no significant difference was found, need to run a dump in staging to get more data.

Bug: https://phabricator.wikimedia.org/T156441