### PR TITLE
Log schema hash mis-matches / migrations at "warn" level; v0.11.1

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -631,7 +631,7 @@ class DB {
             };
         } else {
             // Carry out any backend, config or schema migrations.
-            this.log('info/cassandra/schema_hash_mismatch',
+            this.log('warn/cassandra/schema_hash_mismatch',
                     `Schema hash mismatch: ${currentSchemaInfo.hash} != ${newSchemaInfo.hash}`);
             const migrator = new SchemaMigrator({
                 db: this,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.6",


### PR DESCRIPTION
Schema migrations are significant events and can take a long time, so
should be brought to operators' attention by logging them at the "warn"
level.