### PR TITLE
Don't provide a client key space option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,6 @@ function makeClient(options) {
     const conf = options.conf;
     validateAndNormalizeDcConf(conf);
 
-    clientOpts.keyspace = conf.keyspace || 'system';
     clientOpts.contactPoints = conf.hosts;
 
     // See http://www.datastax.com/drivers/nodejs/2.0/module-policies_loadBalancing-DCAwareRoundRobinPolicy.html

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.6",


### PR DESCRIPTION
Since the new release of the Cassandra-driver the client `keyspace` option matters. Since we reuse the client for many keyspaces, we always provide the keyspace in the request, so we shouldn't provide the client keyspace option. Previously this option was ignored.

I'm not entirely sure what exactly is happening within the driver, but since we share a single client for queries to many keyspaces, we definitely shouldn't set this option.

cc @wikimedia/services 