### PR TITLE
Fix: Quote the keyspace name; release v0.11.2

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -924,10 +924,11 @@ class DB {
      */
     _getReplication(domain, table) {
         const keyspace = this.keyspaceName(domain, table);
-        const ks = this.client.metadata.keyspaces[keyspace];
+        const ks = this.client.metadata.keyspaces[keyspace] ||
+            this.client.metadata.keyspaces[keyspace.slice(1, -1)];
         const datacenters = {};
         if (!ks) {
-            return datacenters;
+            return P.resolve(datacenters);
         }
         Object.keys(ks.strategyOptions).forEach((dc) => {
             datacenters[dc] = parseInt(ks.strategyOptions[dc]);

--- a/lib/db.js
+++ b/lib/db.js
@@ -210,7 +210,7 @@ class DB {
         const reversedName = name.toLowerCase().split('.').reverse().join('.');
         const prefix = dbu.makeValidKey(reversedName, Math.max(26, 48 - table.length - 3));
         // 6 chars _hash_ to prevent conflicts between domains & table names
-        const res = `${prefix}_T_${dbu.makeValidKey(table, 48 - prefix.length - 3)}`;
+        const res = `"${prefix}_T_${dbu.makeValidKey(table, 48 - prefix.length - 3)}"`;
         this.keyspaceNameCache[cacheKey] = res;
         return res;
     }
@@ -288,7 +288,7 @@ class DB {
         // }
 
         // Paging request:
-        const cassOpts = { consistency: req.consistency, prepare: true };
+        const cassOpts = { consistency: req.consistency, prepare: true, keyspace: req.keyspace };
 
         if (req.query.limit) {
             cassOpts.fetchSize = req.query.limit;

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -45,6 +45,10 @@ class HTTPError extends Error {
 dbu.HTTPError = HTTPError;
 
 dbu.cassID = function cassID(name) {
+    if (/^".+"$/.test(name)) {
+      // the name is already quoted, so return it
+      return name;
+    }
     if (/^[a-zA-Z0-9_]+$/.test(name)) {
         return `"${name}"`;
     } else {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -46,8 +46,8 @@ dbu.HTTPError = HTTPError;
 
 dbu.cassID = function cassID(name) {
     if (/^".+"$/.test(name)) {
-      // the name is already quoted, so return it
-      return name;
+        // the name is already quoted, so start by removing the surrounding quotes
+        name = name.slice(1, -1);
     }
     if (/^[a-zA-Z0-9_]+$/.test(name)) {
         return `"${name}"`;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,8 +3,6 @@
 const P = require('bluebird');
 const cass = require('cassandra-driver');
 const fs = require('fs');
-const loadBalancing = cass.policies.loadBalancing;
-const reconnection = cass.policies.reconnection;
 const DB = require('./db');
 
 function validateAndNormalizeDcConf(conf) {
@@ -45,19 +43,7 @@ function makeClient(options) {
     const conf = options.conf;
     validateAndNormalizeDcConf(conf);
 
-    clientOpts.keyspace = conf.keyspace || 'system';
     clientOpts.contactPoints = conf.hosts;
-
-    // See http://www.datastax.com/drivers/nodejs/2.0/module-policies_loadBalancing-DCAwareRoundRobinPolicy.html
-    clientOpts.policies = {
-        loadBalancing: new loadBalancing.TokenAwarePolicy(
-            new loadBalancing.DCAwareRoundRobinPolicy(conf.localDc)
-        ),
-        // Also see
-        // http://www.datastax.com/documentation/developer/nodejs-driver/2.0/common/drivers/reference/clientOptions.html
-        // Retry immediately, then delay by 100ms, back off up to 120s
-        reconnection: new reconnection.ExponentialReconnectionPolicy(100, 120000, true)
-    };
 
     if (conf.tls) {
         try {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.6",
-    "cassandra-driver": "^3.2.0",
+    "cassandra-driver": "^3.2.2",
     "core-js": "^2.4.1",
     "extend": "^3.0.0",
     "js-yaml": "^3.6.1",


### PR DESCRIPTION
The new version of the driver (v3.2.2) actively uses the keyspace name to determine better routes when executing queries, which it previously was not doing. Alas, all of the keyspace names we were providing it were actually wrong, as they were not surrounded by double quotes. This caused the driver to look up metadata in all of the contact points, which resulted in a spiral time-out and retries.