### PR TITLE
Expose default_time_to_live

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -907,7 +907,7 @@ dbu.getOptionCQL = (options, db) => {
     ];
 
     if (options.default_time_to_live) {
-        cqlParts.push(`default_time_to_live = ${options.default_time_to_live}`)
+        cqlParts.push(`default_time_to_live = ${options.default_time_to_live}`);
     }
 
     // Remove falsy parts & join the remainder.

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -906,6 +906,10 @@ dbu.getOptionCQL = (options, db) => {
         dbu.getTableCompactionCQL(options, db),
     ];
 
+    if (options.default_time_to_live) {
+        cqlParts.push(`default_time_to_live = ${options.default_time_to_live}`)
+    }
+
     // Remove falsy parts & join the remainder.
     return cqlParts.filter(Boolean).join(' and ');
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.6",


### PR DESCRIPTION
As we're removing the `revisionRetentionPolicy` from the storage module, we need another way to specify table-level TTLs. So expose the `default_time_to_live` configuration property.

This will also need some changes to the restbase key_rev_value.

Bug: https://phabricator.wikimedia.org/T170901
cc @wikimedia/services 