### PR TITLE
Switch to system_schema.* keyspace for checking if the meta table exist

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -148,9 +148,8 @@ class DB {
                 return req;
             } else {
                 // Check if the meta column family exists
-                return this.client.execute('SELECT columnfamily_name FROM '
-                    + 'system.schema_columnfamilies WHERE keyspace_name=? '
-                    + 'and columnfamily_name=?', [req.keyspace, 'meta'])
+                return this.client.execute('SELECT table_name FROM system_schema.tables '
+                    + 'WHERE keyspace_name=? and table_name=?', [req.keyspace, 'meta'])
                 .then((res) => {
                     if (res && res.rows.length === 0) {
                         // meta column family doesn't exist yet


### PR DESCRIPTION
The `system.schema_columnfamilies` table doesn't exist any more, see https://issues.apache.org/jira/browse/CASSANDRA-10996

cc @wikimedia/services  