### PR TITLE
Remove implicit _TID adding

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,12 +181,10 @@ class RBCassandra {
         return this.store.getTableSchema(domain, req.params.table)
         .then((res) => ({
             status: 200,
-            headers: { etag: res.tid.toString() },
             body: res.schema
         }))
         .catch((e) => ({
             status: 500,
-
             body: {
                 type: 'schema_query_error',
                 title: 'Internal error querying table schema in Cassandra storage backend',

--- a/lib/db.js
+++ b/lib/db.js
@@ -2,7 +2,6 @@
 
 const P = require('bluebird');
 const cass = require('cassandra-driver');
-const TimeUuid = cass.types.TimeUuid;
 const extend = require('extend');
 const dbu = require('./dbutils');
 const cassID = dbu.cassID;
@@ -302,8 +301,6 @@ class DB {
         if (!req.schema) {
             throw new Error('Table not found!');
         }
-        const schema = req.schema;
-        const query = req.query;
         const queryOptions = { consistency: req.consistency, prepare: true };
         const queryInfo = dbu.buildPutQuery(req);
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -68,11 +68,9 @@ class DB {
             attributes: {
                 key: 'string',
                 value: 'json',
-                tid: 'timeuuid'
             },
             index: [
-                { attribute: 'key', type: 'hash' },
-                { attribute: 'tid', type: 'range', order: 'desc' }
+                { attribute: 'key', type: 'hash' }
             ]
         });
         this.infoSchemaInfo = dbu.makeSchemaInfo(this.infoSchema, true);
@@ -306,14 +304,6 @@ class DB {
         }
         const schema = req.schema;
         const query = req.query;
-
-        const tid = query.attributes[schema.tid];
-        if (!tid) {
-            query.attributes[schema.tid] = TimeUuid.now();
-        } else if (tid.constructor === String) {
-            query.attributes[schema.tid] = TimeUuid.fromString(query.attributes[schema.tid]);
-        }
-
         const queryOptions = { consistency: req.consistency, prepare: true };
         const queryInfo = dbu.buildPutQuery(req);
 
@@ -645,7 +635,7 @@ class DB {
                 });
             }
             const item = response.items[0];
-            return { tid: item.tid, schema: JSON.parse(item.value) };
+            return { schema: JSON.parse(item.value) };
         });
     }
 

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -331,11 +331,6 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema, isMetaCF) {
     // Then add some private properties
     psi.versioned = false;
 
-    // Check if the last index entry is a timeuuid, which we take to mean that
-    // this table is versioned
-    const lastElem = schema.index[schema.index.length - 1];
-    const lastKey = lastElem.attribute;
-
     // Extract attributes that need conversion in the read or write path
     psi.conversions = {};
     Object.keys(psi.attributes).forEach((att) => {

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -56,11 +56,6 @@ dbu.cassTTL = function cassTTL(name) {
     return `_ttl_${name}`;
 };
 
-dbu.tidNanoTime = (tid) => {
-    const datePrecision = tid.getDatePrecision();
-    return datePrecision.date.getTime() + datePrecision.ticks / 1000;
-};
-
 // Hash a key into a valid Cassandra key name
 dbu.hashKey = function hashKey(key) {
     return new crypto.Hash('sha1')
@@ -362,17 +357,6 @@ dbu.makeSchemaInfo = function makeSchemaInfo(schema, isMetaCF) {
         // between groups of domains
         psi.attributes._domain = 'string';
         psi.index.unshift({ attribute: '_domain', type: 'hash' });
-    }
-
-    if (lastKey && lastElem.type === 'range'
-            && lastElem.order === 'desc'
-            && schema.attributes[lastKey] === 'timeuuid') {
-        psi.tid = lastKey;
-    } else {
-        // Add a hidden _tid timeuuid attribute
-        psi.attributes._tid = 'timeuuid';
-        psi.index.push({ attribute: '_tid', type: 'range', order: 'desc' });
-        psi.tid = '_tid';
     }
 
     // Create summary data on the primary data index


### PR DESCRIPTION
This one is not quite ready, because we need to adapt the tests and we need to check that RESTBase will not be broken by this, so created a PR to engage the discussion early on. 

Currently we're adding the implicit `tid`(or `_tid`) to all the tables, so we never overwrite the values, we're writing the new value with a new TID and then apply some retention policy. However, since we've got rid of the revision policies, we don't really need to have TID in every schema - it's a too magical and not manageable without retention policies. 

With this change we will be able to convert the `key_value` bucket to use overwriting instead of a rev policy, also we'd be able to create the `timeline` indexes.

Thoughts?

Bug: https://phabricator.wikimedia.org/T170902
cc @wikimedia/services 