### PR TITLE
Support dry-run for schema migrations

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -369,6 +369,7 @@ class DB {
                 db: this,
                 client: this.client,
                 log: this.log,
+                skip_schema_update: this.conf.skip_schema_update
             });
             return P.try(() => migrator.migrate(req, currentSchemaInfo, newSchemaInfo))
             .then((migrated) => {
@@ -675,6 +676,10 @@ class DB {
             replicas: this._replicationPolicy(options),
             durability: options && options.durability || null
         });
+        this.log('trace/alter_schema', cql);
+        if (this.conf.skip_schema_update) {
+            return P.resolve();
+        }
         return this.client.execute(cql, [], { consistency: this.defaultConsistency });
     }
 

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -77,6 +77,10 @@ class Options {
         const table = `${dbu.cassID(req.keyspace)}.${dbu.cassID(req.columnfamily)}`;
         const cql = `ALTER TABLE ${table} WITH ${dbu.getOptionCQL(proposed.options,
         this.options.db)}`;
+        this.options.log('trace/alter_schema', cql);
+        if (this.options.skip_schema_update) {
+            return P.resolve();
+        }
         return this.options.client.execute(cql, [], { consistency: req.consistency });
     }
 }
@@ -101,6 +105,10 @@ class Attributes {
                 column: col
             });
             const cql = this._alterTableAdd(proposed, table, col);
+            this.options.log('trace/alter_schema', cql);
+            if (this.options.skip_schema_update) {
+                return P.resolve();
+            }
             return this.options.client.execute(cql, [], { consistency: req.consistency })
             .catch((e) => {
                 if (!new RegExp(`Invalid column name ${col} because it `
@@ -117,6 +125,10 @@ class Attributes {
                 column: col
             });
             const cql = `ALTER TABLE ${table} DROP ${dbu.cassID(col)}`;
+            this.options.log('trace/alter_schema', cql);
+            if (this.options.skip_schema_update) {
+                return P.resolve();
+            }
             return this.options.client.execute(cql, [], { consistency: req.consistency })
             .catch({ message: `Column ${col} was not found in table data` }, () => {
                 // Ignore the error if the column was already removed.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.6",


### PR DESCRIPTION
This will dry-dun the actual Cassandra schema alternation.

cc @wikimedia/services 