### PR TITLE
Remove automagic compression/compaction settings and migrations.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -542,11 +542,18 @@ class DB {
         cql += 'primary key (';
         cql += `${[`(${hashBits.join(',')})`].concat(rangeBits).join(',')}))`;
 
-        // Add options for compression & compaction
-        cql += ` WITH ${dbu.getOptionCQL(schema.options || {}, this)}`;
 
+        let clusteringCQL;
         if (orderBits.length) {
-            cql += ` and clustering order by ( ${orderBits.join(',')} )`;
+            clusteringCQL = `clustering order by (${orderBits.join(',')})`;
+        }
+        // Add options for default_time_to_live
+        const additionalOptions = [
+            clusteringCQL,
+            dbu.getOptionCQL(schema.options || {}, this)
+        ].filter(Boolean);
+        if (additionalOptions.length) {
+            cql += ` WITH ${additionalOptions.join(' and ')}`;
         }
 
         // TODO: If the table already exists, check that the schema actually

--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -9,7 +9,6 @@ const P = require('bluebird');
 const stableStringify = require('json-stable-stringify');
 const validator = require('restbase-mod-table-spec').validator;
 const Long = require('cassandra-driver').types.Long;
-const semver = require('semver');
 
 /*
  * Various static database utility methods
@@ -174,7 +173,7 @@ dbu.eachRow = function eachRow(client, query, params, options, handler) {
  */
 
 dbu.DEFAULT_BACKEND_VERSION = 0;
-dbu.CURRENT_BACKEND_VERSION = 1;
+dbu.CURRENT_BACKEND_VERSION = 2;
 
 dbu.DEFAULT_CONFIG_VERSION = 0;    // Implicit module config version.
 
@@ -798,99 +797,11 @@ dbu.buildDeleteQuery = (req) => {
     return { cql, params: condition.params };
 };
 
-dbu.getOptionCQL = (options, db) => {
-    // Generate the CQL for each option
-    const cqlParts = [
-        dbu.getTableCompressionCQL(options),
-        dbu.getTableCompactionCQL(options, db),
-    ];
-
+dbu.getOptionCQL = (options) => {
     if (options.default_time_to_live) {
-        cqlParts.push(`default_time_to_live = ${options.default_time_to_live}`);
-    }
-
-    // Remove falsy parts & join the remainder.
-    return cqlParts.filter(Boolean).join(' and ');
-};
-
-const updateOptionMap = {
-    'write-once': "{ 'class' : 'SizeTieredCompactionStrategy', "
-        + "'tombstone_threshold': '0.02' }",
-    'random-update': "{ 'class' : 'LeveledCompactionStrategy' }",
-    timeseries: "{ 'class': 'DateTieredCompactionStrategy', "
-        // Change base_time_seconds from 60s default to 45, for better
-        // alignment with two-day expiry (24 hour TTL + 24 hour
-        // gc_grace_seconds). See also:
-        // https://issues.apache.org/jira/browse/CASSANDRA-8417
-        + "'base_time_seconds': '45',"
-        // More aggressive tombstone collection. Changes from defaults:
-        // - Lowered tombstone_threshold from 0.2 to 0.02
-        // - Enabled unchecked_tombstone_compaction, which allows tombstone
-        // collection even if key ranges overlap with other sstables. See
-        // http://thread.gmane.org/gmane.comp.db.cassandra.devel/9753 and
-        // http://mail-archives.apache.org/mod_mbox/cassandra-commits/201405.mbox/%3C8eaf7fbf908a4e40a77bc26b69ac7867@git.apache.org%3E
-        + "'tombstone_threshold': '0.02', 'unchecked_tombstone_compaction': 'true' }"
-        + " and gc_grace_seconds = 86400",
-};
-
-dbu.getTableCompactionCQL = (options, db) => {
-    let pattern = options.updates && options.updates.pattern;
-    if (!pattern) {
-        // Default to 'random-update'
-        pattern = 'random-update';
-    }
-
-    if (pattern === 'timeseries' && db.cassandraVersion && semver.valid(db.cassandraVersion)) {
-        // DTCS is supported starting from cassandra 2.0.11 or 2.1.1
-        if (!semver.satisfies(db.cassandraVersion, '>= 2.0.11 < 2.1.0 || >= 2.1.1')) {
-            pattern = 'write-once';
-            db.log('warn/updateHints',
-                    `Using STCS instead of DTCS for "timeseries" update `
-                        + `pattern: DTCS not supported by cassandra v${db.cassandraVersion}`);
-        }
-    }
-
-    if (!updateOptionMap[pattern]) {
-        throw new Error(`Invalid update pattern: ${pattern}`);
-    } else {
-        return `compaction = ${updateOptionMap[pattern]}`;
-    }
-};
-
-dbu.validCompressionAlgorithms = {
-    lz4: 'LZ4Compressor',
-    deflate: 'DeflateCompressor',
-    lzma: false,
-    snappy: 'SnappyCompressor'
-};
-
-dbu.validCompressionBlockSizes = {
-    64: 1,
-    128: 1,
-    256: 1,
-    512: 1,
-    1024: 1
-};
-
-dbu.getTableCompressionCQL = (options) => {
-    if (!options.compression) {
-        return;
-    }
-    const compressions = options.compression;
-
-    for (let i = 0; i < compressions.length; i++) {
-        const option = compressions[i];
-        if (option
-                && dbu.validCompressionAlgorithms[option.algorithm]
-                && dbu.validCompressionAlgorithms[option.algorithm].constructor === String
-                && dbu.validCompressionBlockSizes[option.block_size]) {
-            return `compression = { 'sstable_compression' : `
-                + `'${dbu.validCompressionAlgorithms[option.algorithm]}', `
-                + `'chunk_length_kb' : ${option.block_size} }`;
-        }
+        return `default_time_to_live = ${options.default_time_to_live}`;
     }
     return '';
 };
-
 
 module.exports = dbu;

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -65,10 +65,9 @@ class Options {
     }
 
     validate(req, current, proposed) {
-        if (confChanged({ conf: current.options, version: current.version },
+        if (current._backend_version === proposed._backend_version
+                && confChanged({ conf: current.options, version: current.version },
                     { conf: proposed.options, version: proposed.version })) {
-            // Try to generate the options CQL, which implicitly validates it.
-            dbu.getOptionCQL(proposed.options, this.options.db);
             return true;
         }
     }
@@ -255,7 +254,7 @@ class BackendMigrator {
     }
 
     migrate(req, current, proposed) {
-        return this.options.db.migrateBackend(req, current, proposed);
+        return this.options.db._migrateBackend(req, current, proposed);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.6",
@@ -9,9 +9,8 @@
     "core-js": "^2.4.1",
     "extend": "^3.0.0",
     "js-yaml": "^3.6.1",
-    "json-stable-stringify": "git+https://github.com/wikimedia/json-stable-stringify#master",
-    "restbase-mod-table-spec": "^1.0.0",
-    "semver": "^5.3.0"
+    "json-stable-stringify": "^1.0.1",
+    "restbase-mod-table-spec": "^1.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Tested locally that this indeed clears up meta tables from compression/compaction settings without issuing any table alternations. Would be good to deploy this together with a RESTBase PR that would clear up update patterns from the schemas.

cc @wikimedia/services 
