### PR TITLE
Replace `json-stable-stringify` with `fast-json-stable-stringify`

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -6,7 +6,7 @@ const crypto = require('crypto');
 const extend = require('extend');
 const cass = require('cassandra-driver');
 const P = require('bluebird');
-const stableStringify = require('json-stable-stringify');
+const stableStringify = require('fast-json-stable-stringify');
 const validator = require('restbase-mod-table-spec').validator;
 const Long = require('cassandra-driver').types.Long;
 

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -2,7 +2,7 @@
 
 const dbu = require('./dbutils');
 const P = require('bluebird');
-const stringify = require('json-stable-stringify');
+const stringify = require('fast-json-stable-stringify');
 
 /**
  * Check if a schema part differs, and if it does, if the version was

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.5.2",
     "cassandra-driver": "3.5.0",
     "core-js": "^2.5.7",
     "extend": "^3.0.2",
+    "fast-json-stable-stringify": "^2.0.0",
     "js-yaml": "^3.12.0",
-    "json-stable-stringify": "^1.0.1",
     "restbase-mod-table-spec": "^1.1.0",
     "string-align": "^0.2.0",
     "yargs": "^12.0.2"


### PR DESCRIPTION
fast-json-stable-stringify is being used because it does not have any dependencies and has been shown to be faster than json-stable-stringify

Bug: [T210426](https://phabricator.wikimedia.org/T210426)