### PR TITLE
Stringify a Buffer if we want to write it into string type.

### DIFF
--- a/lib/dbutils.js
+++ b/lib/dbutils.js
@@ -313,6 +313,17 @@ dbu.conversions = {
     long: {
         read: toString(),
         write(val) { return Long.fromString(val); }
+    },
+    // Don't stringify anything. It's ok to stringify a Buffer,
+    // but in general we need to catch errors if object or integer
+    // were provided instead of the string.
+    string: {
+        write: (val) => {
+            if (Buffer.isBuffer(val)) {
+                return val.toString();
+            }
+            return val;
+        }
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.5.2",


### PR DESCRIPTION
For RESTBase split some of the legacy tables that we want to reuse were created with string value type. For unusual content-types, like mml or svg we need to stringify the buffer that the backend is receiving.