### PR TITLE
Create keyspaces for all storage groups if * domain is provided

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,4 +1,4 @@
-extends: 
+extends:
   - 'wikimedia/server'
 
 plugins:
@@ -14,11 +14,13 @@ rules:
   computed-property-spacing:
     - error
     - never
-  indent: 
+  indent:
     - error
     - 4
     - SwitchCase: 1
-      MemberExpression: 'off'    
+      MemberExpression: 'off'
+      FunctionExpression:
+        parameters: 'first'
   no-multi-spaces:
     - off
   no-underscore-dangle:

--- a/lib/db.js
+++ b/lib/db.js
@@ -87,18 +87,22 @@ class DB {
     /**
      * Set up internal request-related information and wrap it into an
      * InternalRequest instance.
-     * @param  {string}  domain      in dot notation
-     * @param  {string}  table       logical table name
-     * @param  {Object}  query       query object
-     * @param  {Object}  consistency consistency level
+     * @param  {string}   domain            in dot notation
+     * @param  {string}   table             logical table name
+     * @param  {Object}   query             query object
+     * @param  {Function} [resolveKeyspace] keyspace name resolver
+     * @param  {Object}   [consistency]     consistency level
      * @return {Object}
      */
-    _makeInternalRequest(domain, table, query, consistency) {
-        consistency = consistency || this.defaultConsistency;
+    _makeInternalRequest(domain,
+                         table,
+                         query,
+                         resolveKeyspace = this.keyspaceName.bind(this),
+                         consistency = this.defaultConsistency) {
+        const keyspace = resolveKeyspace(domain, table);
         if (query.consistency && query.consistency in validTextConsistencies) {
             consistency = cass.types.consistencies[query.consistency];
         }
-        const keyspace = this.keyspaceName(domain, table);
         const opts = {
             domain,
             table,
@@ -177,14 +181,24 @@ class DB {
      * @return {string}         Valid Cassandra keyspace key
      */
     keyspaceName(domain, table) {
-        const cacheKey = JSON.stringify([domain, table]);
+        const cacheKey = JSON.stringify(['domain', domain, table]);
         const cachedName = this.keyspaceNameCache[cacheKey];
         if (cachedName) {
             return cachedName;
         }
-
         const name = this._resolveStorageGroup(domain).name;
-        const reversedName = name.toLowerCase().split('.').reverse().join('.');
+        const res = this._keyspaceNameForStorageGroup(name, table);
+        this.keyspaceNameCache[cacheKey] = res;
+        return res;
+    }
+
+    _keyspaceNameForStorageGroup(groupName, table) {
+        const cacheKey = JSON.stringify(['storageGroup', groupName, table]);
+        const cachedName = this.keyspaceNameCache[cacheKey];
+        if (cachedName) {
+            return cachedName;
+        }
+        const reversedName = groupName.toLowerCase().split('.').reverse().join('.');
         const prefix = dbu.makeValidKey(reversedName, Math.max(26, 48 - table.length - 3));
         // 6 chars _hash_ to prevent conflicts between domains & table names
         const res = `${prefix}_T_${dbu.makeValidKey(table, 48 - prefix.length - 3)}`;
@@ -220,12 +234,7 @@ class DB {
             }
         }
         if (!group) {
-            // no group found, assume the domain is to
-            // be grouped by itthis
-            group = {
-                name: domain,
-                domain: [domain]
-            };
+            throw new Error(`No storage group found for ${domain}`);
         }
         // save it in the cache
         this.storageGroupsCache[domain] = group;
@@ -421,8 +430,18 @@ class DB {
         if (!query.table) {
             throw new Error('Table name required.');
         }
+        if (domain === '*') {
+            return P.each(this.storageGroups, (group) =>
+                this._createTableForStorageGroup(group.name, query));
+        } else {
+            const groupName = this._resolveStorageGroup(domain).name;
+            return this._createTableForStorageGroup(groupName, query);
+        }
+    }
 
-        return this._makeInternalRequest(domain, query.table, query)
+    _createTableForStorageGroup(groupName, query) {
+        return this._makeInternalRequest(groupName,
+            query.table, query, this._keyspaceNameForStorageGroup.bind(this))
         .catch((err) => {
             this.log('error/cassandra/table_creation', err);
             throw err;
@@ -603,6 +622,12 @@ class DB {
         return cql;
     }
 
+    /**
+     * Returns the number of replicas per original request options
+     * @param {Object} [options] original request options
+     * @return {number}
+     * @private
+     */
     _replicationPolicy(options) {
         const durability = (options && options.durability === 'low') ? 1 : 3;
         const replicas = {};
@@ -612,11 +637,19 @@ class DB {
         return replicas;
     }
 
-    dropTable(domain, table) {
-        const keyspace = this.keyspaceName(domain, table);
+    _dropTable(keyspace) {
         this.schemaCache[keyspace] = null;
-        return this.client.execute(`drop keyspace ${cassID(keyspace)}`, [],
+        return this.client.execute(`drop keyspace if exists ${cassID(keyspace)}`, [],
             { consistency: this.defaultConsistency });
+    }
+
+    dropTable(domain, table) {
+        if (domain === '*') {
+            return P.each(this.storageGroups, (group) =>
+                this._dropTable(this._keyspaceNameForStorageGroup(group.name, table)));
+        } else {
+            return this._dropTable(this.keyspaceName(domain, table));
+        }
     }
 
     getTableSchema(domain, table) {
@@ -647,17 +680,15 @@ class DB {
 
     /**
      * Retrieves the current replication options for a keyspace.
-     * @param  {string} domain  the domain name
-     * @param  {string} table   the table name
-     * @return {Object} promise that yields an associative array of datacenters with
+     * @param  {string} keyspace the keyspace name
+     * @return {Object} promise  that yields an associative array of datacenters with
      *                  corresponding replication counts
      */
-    _getReplication(domain, table) {
-        const keyspace = this.keyspaceName(domain, table);
+    _getReplication(keyspace) {
         const ks = this.client.metadata.keyspaces[keyspace];
         const datacenters = {};
         if (!ks) {
-            return datacenters;
+            return P.resolve(datacenters);
         }
         Object.keys(ks.strategyOptions).forEach((dc) => {
             datacenters[dc] = parseInt(ks.strategyOptions[dc], 10);
@@ -668,13 +699,11 @@ class DB {
     /**
      * ALTERs a Cassandra keyspace to match the replication policy, (a function of the
      * configured datacenters, and the requested durability).
-     * @param  {string} domain  the domain name
-     * @param  {string} table   the table name
-     * @param  {Object} options query options from the initiating request
-     * @return {Object} promise that resolves when complete
+     * @param  {string} keyspace  the keyspace name
+     * @param  {Object} [options] query options from the initiating request
+     * @return {Object} promise  that resolves when complete
      */
-    _setReplication(domain, table, options) {
-        const keyspace = this.keyspaceName(domain, table);
+    _setReplication(keyspace, options) {
         const cql = `ALTER KEYSPACE ${dbu.cassID(keyspace)} WITH ` +
             `replication = ${this._createReplicationOptionsCQL(options)}`;
         this.log('warn/cassandra/replication', {
@@ -696,12 +725,11 @@ class DB {
      *
      * NOTE: All this does is ALTER the underlying Cassandra keyspace, a repair (or
      * cleanup) is still necessary.
-     * @param  {string} domain  the domain name
-     * @param  {string} table   the table name
-     * @param  {Object} options query options from the initiating request
+     * @param  {string} keyspace  the keyspace name
+     * @param  {Object} [options] query options from the initiating request
      * @return {Object} promise that resolves when complete
      */
-    updateReplicationIfNecessary(domain, table, options) {
+    updateReplicationIfNecessary(keyspace, options) {
         // returns true if two objects have matching keys and values
         const matching = (current, expected) => {
             if (Object.keys(current).length !== Object.keys(expected).length) {
@@ -710,10 +738,10 @@ class DB {
             return Object.keys(current).every((a) => current[a] === expected[a]);
         };
 
-        return this._getReplication(domain, table)
+        return this._getReplication(keyspace)
         .then((current) => {
             if (!matching(current, this._replicationPolicy(options))) {
-                return this._setReplication(domain, table, options);
+                return this._setReplication(keyspace, options);
             }
         });
     }

--- a/lib/schemaMigration.js
+++ b/lib/schemaMigration.js
@@ -216,8 +216,7 @@ class ConfigMigrator {
     }
 
     migrate(req) {
-        return this.options.db.updateReplicationIfNecessary(req.domain,
-            req.query.table, req.query.options);
+        return this.options.db.updateReplicationIfNecessary(req.keyspace, req.query.options);
     }
 }
 
@@ -298,7 +297,7 @@ class SchemaMigrator {
 
     /**
      * Perform any required migration tasks.
-     * @param {req} req the request
+     * @param {InternalRequest} req the request
      * @param {Object} current the current schema
      * @param {Object} proposed the proposed schema
      * @throws {Error} if the proposed migration fails to validate

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.5.2",
@@ -9,7 +9,7 @@
     "extend": "^3.0.2",
     "fast-json-stable-stringify": "^2.0.0",
     "js-yaml": "^3.12.0",
-    "restbase-mod-table-spec": "^1.1.0",
+    "restbase-mod-table-spec": "^1.2.0",
     "string-align": "^0.2.0",
     "yargs": "^12.0.2"
   },

--- a/test/functional/replication.js
+++ b/test/functional/replication.js
@@ -47,17 +47,18 @@ describe('Table creation', () => {
     });
 
     it('updates Cassandra replication', () => {
-        return db._getReplication('restbase.cassandra.test.local', testTable0.table)
+        const keyspace = db.keyspaceName('restbase.cassandra.test.local', testTable0.table);
+        return db._getReplication(keyspace)
         .then((response) => {
             assert.ok(response, 'undefined response');
             assert.strictEqual(Object.keys(response).length, 1, 'incorrect number of results');
 
             // Add one datacenter, and update.
             db.conf.datacenters.push('new_dc');
-            return db.updateReplicationIfNecessary('restbase.cassandra.test.local', testTable0.table);
+            return db.updateReplicationIfNecessary(keyspace);
         })
         .then(() => {
-            return db._getReplication('restbase.cassandra.test.local', testTable0.table);
+            return db._getReplication(keyspace);
         })
         .then((response) => {
             assert.ok(response, 'undefined response');


### PR DESCRIPTION
Now in case the request to create bucket came with a `*` domain, it will create the bucket for all the defined storage groups.

cc @wikimedia/services 