### PR TITLE
Cache table creation operations; release v1.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,6 @@ before_install:
   - echo "-Xmx1g" >> ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - sed -i -e 's/^-XX:+UseNUMA/#-XX:+UseNUMA/' ../apache-cassandra-${CASSANDRA_VERSION}/conf/jvm.options
   - bash ../apache-cassandra-${CASSANDRA_VERSION}/bin/cassandra > /dev/null
+  - sleep 10
 
 script: npm run-script coverage && (npm run-script coveralls || exit 0)

--- a/lib/db.js
+++ b/lib/db.js
@@ -3,6 +3,7 @@
 const P = require('bluebird');
 const cass = require('cassandra-driver');
 const extend = require('extend');
+const crypto = require('crypto');
 const dbu = require('./dbutils');
 const cassID = dbu.cassID;
 const SchemaMigrator = require('./schemaMigration');
@@ -55,8 +56,6 @@ class DB {
 
         /* Process the array of storage groups declared in the config */
         this.storageGroups = this._buildStorageGroups(options.conf.storage_groups);
-        /* The cache holding the already-resolved domain-to-group mappings */
-        this.storageGroupsCache = {};
 
         this.cassandraVersion = this._getCassandraVersion();
 
@@ -82,6 +81,10 @@ class DB {
         this.schemaCache = {};
         // JSON.stringify([domain, table]) -> keyspace
         this.keyspaceNameCache = {};
+        // the cache holding the already-resolved domain-to-group mappings
+        this.storageGroupsCache = {};
+        // the table creation cache - `${group}/${table}` -> result_obj
+        this.tableCreateCache = {};
     }
 
     /**
@@ -369,9 +372,9 @@ class DB {
     _migrateIfNecessary(req, currentSchemaInfo, newSchema, newSchemaInfo) {
         if (currentSchemaInfo.hash === newSchemaInfo.hash) {
             // The fast & standard case. Hashes match, nothing changed.
-            return {
+            return P.resolve({
                 status: 201
-            };
+            });
         } else {
             // Carry out any backend, config or schema migrations.
             this.log('warn/cassandra/schema_hash_mismatch',
@@ -405,9 +408,7 @@ class DB {
                     return P.delay(0);
                 }
             })
-            .then(() => ({
-                status: 201
-            }))
+            .thenReturn({ status: 201 })
             .catch((error) => {
                 const newErr = new dbu.HTTPError({
                     status: 400,
@@ -440,6 +441,7 @@ class DB {
     }
 
     _createTableForStorageGroup(groupName, query) {
+        let creationCacheKey;
         return this._makeInternalRequest(groupName,
             query.table, query, this._keyspaceNameForStorageGroup.bind(this))
         .catch((err) => {
@@ -453,9 +455,25 @@ class DB {
             const newSchema = dbu.validateAndNormalizeSchema(req.query, this.conf.version);
             const newSchemaInfo = dbu.makeSchemaInfo(newSchema);
 
+            if (!this.conf.skip_table_creation_cache) {
+                const schemaHash = crypto.createHash('sha256')
+                    .update(newSchemaInfo.hash)
+                    .digest('hex');
+                creationCacheKey = `${groupName}/${schemaHash}`;
+                if (this.tableCreateCache[creationCacheKey]) {
+                    return P.resolve(Object.assign({}, this.tableCreateCache[creationCacheKey]));
+                }
+            }
+
             if (currentSchemaInfo) {
                 // Table already exists
-                return this._migrateIfNecessary(req, currentSchemaInfo, newSchema, newSchemaInfo);
+                return this._migrateIfNecessary(req, currentSchemaInfo, newSchema, newSchemaInfo)
+                .then((res) => {
+                    if (!this.conf.skip_table_creation_cache) {
+                        this.tableCreateCache[creationCacheKey] = Object.assign({}, res);
+                    }
+                    return P.resolve(res);
+                });
             }
 
             // Cassandra does not like concurrent keyspace creation. This is
@@ -494,9 +512,13 @@ class DB {
                         }
                     });
                     return this._put(putReq)
-                    .then(() => ({
-                        status: 201
-                    }));
+                    .then(() => {
+                        const res = { status: 201 };
+                        if (!this.conf.skip_table_creation_cache) {
+                            this.tableCreateCache[creationCacheKey] = Object.assign({}, res);
+                        }
+                        return P.resolve(res);
+                    });
                 })
                 .catch((e) => {
                     // TODO: proper error reporting:

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "restbase-mod-table-cassandra",
   "description": "RESTBase table storage on Cassandra",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "Apache-2.0",
   "dependencies": {
-    "bluebird": "^3.5.2",
+    "bluebird": "^3.5.5",
     "cassandra-driver": "3.5.0",
     "extend": "^3.0.2",
     "fast-json-stable-stringify": "^2.0.0",
-    "js-yaml": "^3.12.0",
+    "js-yaml": "^3.13.1",
     "restbase-mod-table-spec": "^1.2.0",
     "string-align": "^0.2.0",
-    "yargs": "^12.0.2"
+    "yargs": "^14.0.0"
   },
   "repository": {
     "type": "git",

--- a/test/functional/config_migrations.js
+++ b/test/functional/config_migrations.js
@@ -73,15 +73,15 @@ describe('Configuration migration', () => {
     });
 
     it('disallows decreasing versions', () => {
-        // Migrate version (from 1) to 2.
-        db.conf.version = 2;
+        // Migrate version (from 1) to 4.
+        db.conf.version = 4;
         return db.createTable('restbase.cassandra.test.local', testTable0)
         .then((response) => {
             assert.ok(response, 'undefined response');
             assert.deepEqual(response.status, 201);
 
-            // Attempt to downgrade version (from 2) to 1
-            db.conf.version = 1;
+            // Attempt to downgrade version (from 4) to 3
+            db.conf.version = 3;
             return db.createTable('restbase.cassandra.test.local', testTable0)
             .then((response) => {
                 // A successful response means a downgrade happened (this is wrong).


### PR DESCRIPTION
Since we execute identical PUT /bucket requests for all domains within
the same storage group, use a cache to speed up the start-up sequence.
The cache is per-group and per-table.

In order to disable the cache, one can set `skip_table_creation_cache`
to `true` in the module config.